### PR TITLE
fix naming error in readme and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Here is how you might construct a parser for text in the form `(a, b, c, ...)` w
 	//Built-in building block parser for floating point numbers.
 	let tupleElement = Parjs.float();
 	//Allow whitespace around elements:
-	let paddedElement = tupleElement.between(Parjs.spaces);
+	let paddedElement = tupleElement.between(Parjs.whitespaces);
 	//Multiple instances of {paddedElement}, separated by a comma:
 	let separated = paddedElement.manySepBy(Parjs.string(","));
 	//Surround everything with parentheses:

--- a/docs/index.html
+++ b/docs/index.html
@@ -110,7 +110,7 @@
 				<pre><code><span class="hljs-comment">//Built-in building block parser for floating point numbers.</span>
 <span class="hljs-keyword">let</span> tupleElement = Parjs.float();
 <span class="hljs-comment">//Allow whitespace around elements:</span>
-<span class="hljs-keyword">let</span> paddedElement = tupleElement.between(Parjs.spaces);
+<span class="hljs-keyword">let</span> paddedElement = tupleElement.between(Parjs.whitespaces);
 <span class="hljs-comment">//Multiple instances of {paddedElement}, separated by a comma:</span>
 <span class="hljs-keyword">let</span> separated = paddedElement.manySepBy(Parjs.<span class="hljs-keyword">string</span>(<span class="hljs-string">","</span>));
 <span class="hljs-comment">//Surround everything with parentheses:</span>


### PR DESCRIPTION
the readme and the first page of the API docs incorrectly use `Parser.spaces`, which does not exist, instead of `Parser.whitespaces`. This PR corrects that. Closes #10 