### PR TITLE
Remove spurious this.reason

### DIFF
--- a/src/lib/internal/parsers/regexp.ts
+++ b/src/lib/internal/parsers/regexp.ts
@@ -18,7 +18,7 @@ import {ParjserBase} from "../parser";
 export function regexp(origRegexp: RegExp): Parjser<string[]> {
     let flags = [origRegexp.ignoreCase && "i", origRegexp.multiline && "m"].filter(x => x).join("");
     let regexp = new RegExp(origRegexp.source, `${flags}y`);
-    this.reason = `expecting input matching /${origRegexp.source}/`;
+
     return new class Regexp extends ParjserBase {
         type = "regexp";
         expecting = `expecting input matching '${regexp.source}'`;


### PR DESCRIPTION
Looks like something left over from an old API, replaced by `expecting = ...`? It breaks when a `regexp(...).pipe(...)` parser fails, because `this` is undefined. Removing it should fix the problem.

Example case:

```js
"use strict";

const { regexp } = require("parjs");
const { many, must } = require("parjs/combinators");

let ipv6Address = regexp(/[a-f0-9]:./i).pipe(
	many(),
	must((ip) => ip.length >= 2 && ip.length <= 45)
);

console.log(ipv6Address.parse("foo"));
```

Error:

```
/home/sven/Private/projects/modular-matrix/client/node_modules/parjs/internal/parsers/regexp.js:19
    this.reason = `expecting input matching /${origRegexp.source}/`;
                ^

TypeError: Cannot set property 'reason' of undefined
    at regexp (/home/sven/Private/projects/modular-matrix/client/node_modules/parjs/internal/parsers/regexp.js:19:17)
    at Object.<anonymous> (/home/sven/Private/projects/modular-matrix/client/test-parse.js:6:19)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)
```