### PR TITLE
Fix typo in errors.ts

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -21,7 +21,7 @@ export abstract class ParjsError extends Error {
  */
 export class ParjsParsingFailure extends ParjsError {
     constructor(public failure: ParjsFailure) {
-        super(`Expected parsing to succeeded, but it failed. Reason: ${failure.trace.reason}`);
+        super(`Expected parsing to succeed, but it failed. Reason: ${failure.trace.reason}`);
     }
 }
 


### PR DESCRIPTION
Hi, thanks for this useful library. I'm using it in my project https://github.com/sp3ctum/hare to parse Japanese language dictionary definitions :)

Wanted to propose a small typo fix, please let me know if there is something I should do before it can be merged.