### PR TITLE
Feature: small improvements

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,6 @@ import { Config } from "jest";
 
 const config: Config = {
     preset: "ts-jest",
-    collectCoverage: true,
     setupFilesAfterEnv: [path.join(__dirname, "src", "test", "helpers", "jest-setup.ts")],
     testPathIgnorePatterns: ["dist"],
     transform: {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,7 +2,6 @@ import path from "path";
 import { Config } from "jest";
 
 const config: Config = {
-    preset: "ts-jest",
     setupFilesAfterEnv: [path.join(__dirname, "src", "test", "helpers", "jest-setup.ts")],
     testPathIgnorePatterns: ["dist"],
     transform: {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "@typescript-eslint/parser": "6.9.1",
         "eslint": "8.54.0",
         "eslint-plugin-jest": "27.6.0",
-        "jest": "29.7.0",
+        "jest": "30.0.0-alpha.2",
         "npm-run-all": "4.1.5",
         "prettier": "3.0.3",
         "shelljs": "0.8.5",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
         "shx": "0.3.4",
         "source-map": "0.7.4",
         "source-map-support": "0.5.21",
-        "ts-jest": "29.1.1",
         "ts-node": "10.9.1",
         "typedoc": "0.25.3",
         "typedoc-plugin-internal-external": "2.2.0",

--- a/src/lib/internal/combinators/or.ts
+++ b/src/lib/internal/combinators/or.ts
@@ -3,12 +3,12 @@
  */
 /** */
 
-import { ParsingState } from "../state";
-import { ResultKind } from "../result";
 import { ParjsCombinator } from "../..";
-import { ImplicitParjser, ScalarConverter } from "../scalar-converter";
-import { defineCombinator } from "./combinator";
 import { ParjserBase } from "../parser";
+import { ResultKind } from "../result";
+import { ImplicitParjser, ScalarConverter } from "../scalar-converter";
+import { ParsingState } from "../state";
+import { defineCombinator } from "./combinator";
 
 /**
  * Applies the source parser. If it fails softly, will try to apply the
@@ -20,7 +20,7 @@ import { ParjserBase } from "../parser";
  *
  * @param alt1 The first alternative parser to apply.
  */
-export function or<T1, T2>(alt1: ImplicitParjser<T2>): ParjsCombinator<T1, T1 | T2>;
+export function or<const T1, const T2>(alt1: ImplicitParjser<T2>): ParjsCombinator<T1, T1 | T2>;
 
 /**
  * Applies the source parser. If it fails softly, will try to apply the
@@ -33,7 +33,7 @@ export function or<T1, T2>(alt1: ImplicitParjser<T2>): ParjsCombinator<T1, T1 | 
  * @param alt1 The first alternative parser to apply.
  * @param alt2 The second alternative parser to apply.
  */
-export function or<T1, T2, T3>(
+export function or<const T1, const T2, const T3>(
     alt1: ImplicitParjser<T2>,
     alt2: ImplicitParjser<T3>
 ): ParjsCombinator<T1, T1 | T2 | T3>;
@@ -50,7 +50,7 @@ export function or<T1, T2, T3>(
  * @param alt2 The second alternative parser to apply.
  * @param alt3 The third alternative parser to apply.
  */
-export function or<T1, T2, T3, T4>(
+export function or<const T1, const T2, const T3, const T4>(
     alt1: ImplicitParjser<T2>,
     alt2: ImplicitParjser<T3>,
     alt3: ImplicitParjser<T4>
@@ -69,7 +69,7 @@ export function or<T1, T2, T3, T4>(
  * @param alt3 The third alternative parser to apply.
  * @param alt4 The fourth alternative parser to apply.
  */
-export function or<T1, T2, T3, T4, T5>(
+export function or<const T1, const T2, const T3, const T4, const T5>(
     alt1: ImplicitParjser<T2>,
     alt2: ImplicitParjser<T3>,
     alt3: ImplicitParjser<T4>,

--- a/src/lib/internal/combinators/recover.ts
+++ b/src/lib/internal/combinators/recover.ts
@@ -3,12 +3,12 @@
  */
 /** */
 
-import { ParsingState, UserState } from "../state";
-import { FailureInfo, ResultKind, SuccessInfo } from "../result";
 import { ParjsCombinator } from "../../";
+import { FailureInfo, ResultKind, SuccessInfo } from "../result";
+import { ParsingState, UserState } from "../state";
 
-import { defineCombinator } from "./combinator";
 import { ParjserBase } from "../parser";
+import { defineCombinator } from "./combinator";
 
 /**
  * Information about the failure.
@@ -40,7 +40,7 @@ export type RecoveryFunction<T> = (
 /**
  * Reduces Hard failures to Soft ones and behaves in the same way on success.
  */
-export function recover<T>(recoverFunction: RecoveryFunction<T>): ParjsCombinator<unknown, T> {
+export function recover<T>(recoverFunction: RecoveryFunction<T>): ParjsCombinator<T, T> {
     return defineCombinator<unknown, T>(source => {
         return new (class Soft extends ParjserBase<T> {
             type = "recover";

--- a/src/lib/internal/parjser.ts
+++ b/src/lib/internal/parjser.ts
@@ -3,8 +3,8 @@
  */ /** */
 
 import { FailureInfo, ParjsResult } from "./result";
-import { UserState } from "./state";
 import { ImplicitParjser } from "./scalar-converter";
+import { UserState } from "./state";
 
 /**
  * A combinator or operator that takes a source parser that returns a new parser
@@ -57,7 +57,7 @@ export interface Parjser<T> {
      * this parser, feeding the result of one into the input of the next.
      * @param cmb1 The single combinator to apply.
      */
-    pipe<T1>(cmb1: ParjsCombinator<T, T1>): Parjser<T1>;
+    pipe<const T1>(cmb1: ParjsCombinator<T, T1>): Parjser<T1>;
 
     /**
      * The chaining or piping operator. Applies a sequence of combinators to
@@ -65,7 +65,10 @@ export interface Parjser<T> {
      * @param cmb1 The first combinator to apply.
      * @param cmb2 The second combinator to apply.
      */
-    pipe<T1, T2>(cmb1: ParjsCombinator<T, T1>, cmb2: ParjsCombinator<T1, T2>): Parjser<T2>;
+    pipe<const T1, const T2>(
+        cmb1: ParjsCombinator<T, T1>,
+        cmb2: ParjsCombinator<T1, T2>
+    ): Parjser<T2>;
 
     /**
      * The chaining or piping operator. Applies a sequence of combinators to
@@ -74,7 +77,7 @@ export interface Parjser<T> {
      * @param cmb2 The second combinator to apply.
      * @param cmb3 The third combinator to apply.
      */
-    pipe<T1, T2, T3>(
+    pipe<const T1, const T2, const T3>(
         cmb1: ParjsCombinator<T, T1>,
         cmb2: ParjsCombinator<T1, T2>,
         cmb3: ParjsCombinator<T2, T3>
@@ -88,7 +91,7 @@ export interface Parjser<T> {
      * @param cmb3 The third combinator to apply.
      * @param cmb4 The fourth combinator to apply.
      */
-    pipe<T1, T2, T3, T4>(
+    pipe<const T1, const T2, const T3, const T4>(
         cmb1: ParjsCombinator<T, T1>,
         cmb2: ParjsCombinator<T1, T2>,
         cmb3: ParjsCombinator<T2, T3>,
@@ -104,7 +107,7 @@ export interface Parjser<T> {
      * @param cmb4 The fourth combinator to apply.
      * @param cmb5 The fifth combinator to apply.
      */
-    pipe<T1, T2, T3, T4, T5>(
+    pipe<const T1, const T2, const T3, const T4, const T5>(
         cmb1: ParjsCombinator<T, T1>,
         cmb2: ParjsCombinator<T1, T2>,
         cmb3: ParjsCombinator<T2, T3>,
@@ -122,7 +125,7 @@ export interface Parjser<T> {
      * @param cmb5 The fifth combinator to apply.
      * @param cmb6 The sixth combinator to apply.
      */
-    pipe<T1, T2, T3, T4, T5, T6>(
+    pipe<const T1, const T2, const T3, const T4, const T5, const T6>(
         cmb1: ParjsCombinator<T, T1>,
         cmb2: ParjsCombinator<T1, T2>,
         cmb3: ParjsCombinator<T2, T3>,

--- a/src/lib/internal/parser.ts
+++ b/src/lib/internal/parser.ts
@@ -3,13 +3,18 @@
  */
 /** */
 
+import clone from "lodash/clone";
+import defaults from "lodash/defaults";
+import { ScalarConverter } from ".";
+import { ParserDefinitionError } from "../errors";
+import { ParjsCombinator, Parjser } from "./parjser";
 import {
+    ErrorLocation,
     ParjsFailure,
     ParjsResult,
-    ResultKind,
     ParjsSuccess,
-    Trace,
-    ErrorLocation
+    ResultKind,
+    Trace
 } from "./result";
 import {
     BasicParsingState,
@@ -18,12 +23,6 @@ import {
     UNINITIALIZED_RESULT,
     UserState
 } from "./state";
-import defaults from "lodash/defaults";
-import { ParserDefinitionError } from "../errors";
-import { ParjsCombinator, Parjser } from "./parjser";
-import { pipe } from "./combinators/combinator";
-import clone from "lodash/clone";
-import { ScalarConverter } from ".";
 
 function getErrorLocation(ps: ParsingState) {
     const endln = /\r\n|\n|\r/g;

--- a/src/lib/internal/parser.ts
+++ b/src/lib/internal/parser.ts
@@ -61,7 +61,7 @@ export abstract class ParjserBase<TValue> implements Parjser<TValue> {
     expects(expecting: string): Parjser<TValue> {
         const copy = clone(this);
         copy.expecting = expecting;
-        return copy as Parjser<TValue>;
+        return copy;
     }
     /**
      * Apply the parser to the given state.
@@ -165,6 +165,6 @@ export abstract class ParjserBase<TValue> implements Parjser<TValue> {
             last = pipe(last, cmb as ParjsCombinator<unknown, unknown>);
         }
 
-        return last as unknown as Parjser<T6>;
+        return last as Parjser<T6>;
     }
 }

--- a/src/lib/internal/parser.ts
+++ b/src/lib/internal/parser.ts
@@ -162,7 +162,7 @@ export abstract class ParjserBase<TValue> implements Parjser<TValue> {
         let last: any = ScalarConverter.convert(this);
 
         for (const cmb of combinators) {
-            last = pipe(last, cmb as ParjsCombinator<unknown, unknown>);
+            last = (cmb as ParjsCombinator<unknown, unknown>)(last);
         }
 
         return last as Parjser<T6>;

--- a/src/lib/internal/parser.ts
+++ b/src/lib/internal/parser.ts
@@ -94,7 +94,7 @@ export abstract class ParjserBase<TValue> implements Parjser<TValue> {
             if (ps.reason == null) {
                 throw new ParserDefinitionError(this.type, "a failure must have a reason");
             }
-            ps.stack.push(this as unknown as Parjser<unknown>);
+            ps.stack.push(this);
         } else {
             ps.stack = [];
         }

--- a/src/lib/internal/parsers/char-types.ts
+++ b/src/lib/internal/parsers/char-types.ts
@@ -29,7 +29,7 @@ export function anyChar(): Parjser<string> {
 }
 
 /**
- * Returns a parser that parses a single ASCII inline space.
+ * Returns a parser that parses a single space (`[ \t]`).
  */
 export function space(): Parjser<string> {
     return charWhere(x => isSpace(x) || { reason: "expecting a space" });

--- a/src/lib/internal/parsers/string-of.ts
+++ b/src/lib/internal/parsers/string-of.ts
@@ -12,10 +12,11 @@ import { Parjser } from "../parjser";
  * Returns a parser that will parse any of the strings in `strs` and yield
  * the text that was parsed. If it can't, it will fail softly without consuming
  * input.
- * @param strs A set of string options to parse.
+ * @param strs A set of string options to parse. In typescript, you can also use
+ * a constant tuple if you pass it in using the spread operator (`...`).
  */
-export function anyStringOf(...strs: string[]): Parjser<string> {
-    return new (class StringOf extends ParjserBase<string> {
+export function anyStringOf<T extends string>(...strs: T[]): Parjser<T> {
+    return new (class StringOf extends ParjserBase<T> {
         type = "anyStringOf";
         expecting = `expecting any of ${strs.map(x => `'${x}'`).join(", ")}`;
 

--- a/src/lib/internal/parsers/string.ts
+++ b/src/lib/internal/parsers/string.ts
@@ -13,8 +13,8 @@ import { Parjser } from "..";
  * that was parsed. If it can't, it will fail softly without consuming input.
  * @param str The string to parse.
  */
-export function string(str: string): Parjser<string> {
-    return new (class ParseString extends ParjserBase<string> {
+export function string<T extends string>(str: T): Parjser<T> {
+    return new (class ParseString extends ParjserBase<T> {
         expecting = `expecting '${str}'`;
         type = "string";
         _apply(ps: ParsingState): void {

--- a/src/lib/internal/scalar-converter.ts
+++ b/src/lib/internal/scalar-converter.ts
@@ -5,8 +5,8 @@
 
 import { Parjser } from "./parjser";
 
-import { string } from "./parsers/string";
 import { regexp } from "./parsers/regexp";
+import { string } from "./parsers/string";
 
 /**
  * A {@link Parjser} or a literal value convertible to a {@link Parjser}.

--- a/src/lib/internal/state.ts
+++ b/src/lib/internal/state.ts
@@ -74,7 +74,7 @@ export interface ParsingState {
     atMost(kind: ResultKind): boolean | undefined;
 }
 
-function worseThan(a: ResultKind, b: ResultKind) {
+function worseThan(a: ResultKind, b: ResultKind): boolean | undefined {
     if (a === ResultKind.Ok) {
         return b === ResultKind.Ok;
     }

--- a/src/lib/internal/state.ts
+++ b/src/lib/internal/state.ts
@@ -3,7 +3,7 @@
  */
 /** */
 import { ResultKind } from "./result";
-import { Parjser } from "./parjser";
+import { ParjserBase } from ".";
 
 /**
  * Container type for user state data.
@@ -41,7 +41,7 @@ export interface ParsingState {
     /**
      * A stack that indicates entered parsers. Should not be modified by user code.
      */
-    stack: Parjser<unknown>[];
+    stack: ParjserBase<unknown>[];
 
     /**
      * If the result is a failure, this field will indicate the reason for the failure.

--- a/src/lib/internal/state.ts
+++ b/src/lib/internal/state.ts
@@ -130,8 +130,6 @@ export class BasicParsingState<TValue> implements ParsingState {
     }
 }
 
-// tslint:disable:naming-convention
-
 /**
  * A unique object value indicating the reuslt of a failed parser.
  */

--- a/src/lib/internal/trace-visualizer.ts
+++ b/src/lib/internal/trace-visualizer.ts
@@ -7,6 +7,7 @@ import { Trace } from "./result";
 import { NumHelpers } from "./functions/helpers";
 import repeat from "lodash/repeat";
 import defaults from "lodash/defaults";
+import { ParjserBase } from "./parser";
 
 /**
  * A set of arguments for the trace visualizer.
@@ -50,19 +51,25 @@ function newTraceVisualizer(pAgs: Partial<TraceVisualizerArgs>) {
         linesAround.push(errorMarked);
         const linesVisualization = linesAround.join("\n");
 
+        const stack = trace.stackTrace
+            .map(x => {
+                const base = x as ParjserBase<unknown>;
+                return `${base.expecting} (${x.type})`;
+            })
+            .filter(x => x)
+            .join("\n");
         const fullVisualization = `${trace.kind} failure at Ln ${trace.location.line + 1} Col ${
             trace.location.column + 1
         }
 ${linesVisualization}
-Stack: ${trace.stackTrace
-            .map(x => x.type)
-            .filter(x => x)
-            .join(" < ")}
+
+Stack:
+${stack}
 `;
         return fullVisualization;
     };
     visualizer.configure = newTraceVisualizer;
-    return visualizer as TraceVisualizer;
+    return visualizer;
 }
 
 /**

--- a/src/test/helpers/jest-setup.ts
+++ b/src/test/helpers/jest-setup.ts
@@ -21,7 +21,7 @@ const toBeSuccessful: MatcherFunction<[value: unknown]> =
         }
 
         if (!isParjsSuccess(actual)) {
-            return fail(`expected the parse result ${actual} to be a ParjsSuccess instance`);
+            return fail(`expected the parse result to be a ParjsSuccess instance:\n\n${actual}`);
         }
 
         const actualString = JSON.stringify(actual);

--- a/src/test/helpers/jest-setup.ts
+++ b/src/test/helpers/jest-setup.ts
@@ -17,7 +17,9 @@ const toBeSuccessful: MatcherFunction<[value: unknown]> =
     // jest recommends to type the parameters as `unknown` and to validate the values
     function (actual: unknown, expected: unknown): SyncExpectationResult {
         if (!isParjsResult(actual)) {
-            throw new Error("toBeSuccessful must be called on a ParjsResult");
+            throw new Error(
+                `toBeSuccessful must be called on a ParjsResult, but was called on ${typeof actual}`
+            );
         }
 
         if (!isParjsSuccess(actual)) {

--- a/src/test/helpers/jest-setup.ts
+++ b/src/test/helpers/jest-setup.ts
@@ -24,9 +24,10 @@ const toBeSuccessful: MatcherFunction<[value: unknown]> =
             return fail(`expected the parse result ${actual} to be a ParjsSuccess instance`);
         }
 
+        const actualString = JSON.stringify(actual);
         if (actual.kind !== "OK") {
             return fail(
-                `expected the parse result ${actual} to have kind 'OK' but it had kind '${actual.kind}'`
+                `expected the parse result ${actualString} to have kind 'OK' but it had kind '${actual.kind}'`
             );
         }
 
@@ -35,9 +36,7 @@ const toBeSuccessful: MatcherFunction<[value: unknown]> =
                 // check the structure of the objects, not their references
                 expect(actual.value).toEqual(expected);
             } catch (error) {
-                return fail(
-                    `expected the parse result ${actual} to have value ${expected}.\n\n${error}`
-                );
+                return fail(`Unexpected parser result value. \n\n${error}`);
             }
         }
 
@@ -57,16 +56,18 @@ const toBeFailure: MatcherFunction<[kind?: string]> = function (
         throw new Error("toBeFailure must be called on a ParjsResult");
     }
 
+    const actualString = JSON.stringify(actual);
+
     if (!isParjsFailure(actual)) {
         return fail(
-            `expected the parse result ${actual} to be a ParjsFailure instance, but its type is '${typeof actual}'`
+            `expected the parse result ${actualString} to be a ParjsFailure instance, but its type is '${typeof actual}'`
         );
     }
 
     // if a kind was specified, check it
     if (expected !== undefined && actual.kind !== expected) {
         return fail(
-            `expected the parse result ${actual} to have kind '${expected}' but it had kind '${actual.kind}'`
+            `expected the parse result ${actualString} to have kind '${expected}' but it had kind '${actual.kind}'`
         );
     }
 

--- a/src/test/unit/standalone/string.spec.ts
+++ b/src/test/unit/standalone/string.spec.ts
@@ -126,6 +126,9 @@ describe("basic string parsers", () => {
 
     describe("string(hi)", () => {
         const parser = string("hi");
+        // when parsing, the return type of the parser is what was parsed, literally
+        parser satisfies Parjser<"hi">;
+
         const success = "hi";
         const fail = "bo";
         it("success", () => {

--- a/src/test/unit/standalone/string.spec.ts
+++ b/src/test/unit/standalone/string.spec.ts
@@ -1,4 +1,6 @@
-import { ResultKind } from "../../../lib/internal/result";
+import _ from "lodash";
+import { ParjsResult, Parjser } from "../../../lib";
+import { then } from "../../../lib/combinators";
 import {
     anyChar,
     anyCharOf,
@@ -12,10 +14,8 @@ import {
     string,
     stringLen
 } from "../../../lib/internal/parsers";
-import { letter, lower, spaces1, upper } from "../../../lib/internal/parsers/char-types";
-import { map, then } from "../../../lib/combinators";
-import _ from "lodash";
-import { ParjsResult, Parjser } from "../../../lib";
+import { letter, lower, space, spaces1, upper } from "../../../lib/internal/parsers/char-types";
+import { ResultKind } from "../../../lib/internal/result";
 
 const uState = {};
 
@@ -33,6 +33,16 @@ describe("basic string parsers", () => {
         });
         it("fails on too long input", () => {
             expect(parser.parse(tooLongInput, uState)).toBeFailure(ResultKind.SoftFail);
+        });
+    });
+
+    describe("space", () => {
+        it("can parse a space", () => {
+            expect(space().parse(" ")).toBeSuccessful(" ");
+        });
+
+        it("can parse a tab", () => {
+            expect(space().parse("\t")).toBeSuccessful("\t");
         });
     });
 

--- a/src/test/unit/standalone/string.spec.ts
+++ b/src/test/unit/standalone/string.spec.ts
@@ -13,8 +13,9 @@ import {
     stringLen
 } from "../../../lib/internal/parsers";
 import { letter, lower, spaces1, upper } from "../../../lib/internal/parsers/char-types";
-import { then } from "../../../lib/combinators";
+import { map, then } from "../../../lib/combinators";
 import _ from "lodash";
+import { ParjsResult, Parjser } from "../../../lib";
 
 const uState = {};
 
@@ -138,22 +139,30 @@ describe("basic string parsers", () => {
         });
     });
 
-    describe("anyStringOf(hi, hello)", () => {
-        const parser = anyStringOf("hi", "hello");
-        const success1 = "hello";
-        const success2 = "hi";
-        const fail = "bo";
+    describe("anyStringOf", () => {
         it("success1", () => {
-            expect(parser.parse(success1)).toBeSuccessful(success1);
+            expect(anyStringOf("hi", "hello").parse("hello")).toBeSuccessful("hello");
         });
         it("success2", () => {
-            expect(parser.parse(success2)).toBeSuccessful(success2);
+            expect(anyStringOf("hi", "hello").parse("hi")).toBeSuccessful("hi");
         });
         it("fail", () => {
-            expect(parser.parse(fail)).toBeFailure(ResultKind.SoftFail);
+            expect(anyStringOf("hi", "hello").parse("bo")).toBeFailure(ResultKind.SoftFail);
         });
         it("fail too long", () => {
-            expect(parser.parse(`${success2}1`)).toBeFailure(ResultKind.SoftFail);
+            expect(anyStringOf("hi", "hello").parse(`hi1`)).toBeFailure(ResultKind.SoftFail);
+        });
+
+        it("retains type information when using constant tuples", () => {
+            const letters = ["a", "b", "c"] as const;
+            letters satisfies readonly ["a", "b", "c"]; // must be a constant tuple
+
+            // type information must be retained in the parser type
+            const parser: Parjser<"a" | "c" | "b"> = anyStringOf(...letters);
+
+            // type information must be retained in the result type
+            const result: ParjsResult<"a" | "c" | "b"> = parser.parse("a");
+            expect(result).toBeSuccessful("a");
         });
     });
 

--- a/src/test/unit/standalone/string.spec.ts
+++ b/src/test/unit/standalone/string.spec.ts
@@ -14,7 +14,14 @@ import {
     string,
     stringLen
 } from "../../../lib/internal/parsers";
-import { letter, lower, space, spaces1, upper } from "../../../lib/internal/parsers/char-types";
+import {
+    letter,
+    lower,
+    space,
+    spaces1,
+    upper,
+    whitespace
+} from "../../../lib/internal/parsers/char-types";
 import { ResultKind } from "../../../lib/internal/result";
 
 const uState = {};
@@ -43,6 +50,20 @@ describe("basic string parsers", () => {
 
         it("can parse a tab", () => {
             expect(space().parse("\t")).toBeSuccessful("\t");
+        });
+    });
+
+    describe("whitespace", () => {
+        it("can parse a space", () => {
+            expect(whitespace().parse(" ")).toBeSuccessful(" ");
+        });
+
+        it("can parse a tab", () => {
+            expect(whitespace().parse("\t")).toBeSuccessful("\t");
+        });
+
+        it("can parse a newline", () => {
+            expect(whitespace().parse("\n")).toBeSuccessful("\n");
         });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,50 +562,50 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/console@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/console@npm:29.7.0"
+"@jest/console@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "@jest/console@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/types": "npm:^29.6.3"
+    "@jest/types": "npm:30.0.0-alpha.2"
     "@types/node": "npm:*"
     chalk: "npm:^4.0.0"
-    jest-message-util: "npm:^29.7.0"
-    jest-util: "npm:^29.7.0"
+    jest-message-util: "npm:30.0.0-alpha.2"
+    jest-util: "npm:30.0.0-alpha.2"
     slash: "npm:^3.0.0"
-  checksum: 7be408781d0a6f657e969cbec13b540c329671819c2f57acfad0dae9dbfe2c9be859f38fe99b35dba9ff1536937dc6ddc69fdcd2794812fa3c647a1619797f6c
+  checksum: 2b30d33c3eb0121f4ef34853ff9e6c7d2f1727c4151b1d205f4b1a1004cb3850a6abc510a64aa97cea9b1b3a5701f2382b722726a11bb477f54584c6bffc268a
   languageName: node
   linkType: hard
 
-"@jest/core@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/core@npm:29.7.0"
+"@jest/core@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "@jest/core@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/console": "npm:^29.7.0"
-    "@jest/reporters": "npm:^29.7.0"
-    "@jest/test-result": "npm:^29.7.0"
-    "@jest/transform": "npm:^29.7.0"
-    "@jest/types": "npm:^29.6.3"
+    "@jest/console": "npm:30.0.0-alpha.2"
+    "@jest/reporters": "npm:30.0.0-alpha.2"
+    "@jest/test-result": "npm:30.0.0-alpha.2"
+    "@jest/transform": "npm:30.0.0-alpha.2"
+    "@jest/types": "npm:30.0.0-alpha.2"
     "@types/node": "npm:*"
     ansi-escapes: "npm:^4.2.1"
     chalk: "npm:^4.0.0"
-    ci-info: "npm:^3.2.0"
+    ci-info: "npm:^4.0.0"
     exit: "npm:^0.1.2"
     graceful-fs: "npm:^4.2.9"
-    jest-changed-files: "npm:^29.7.0"
-    jest-config: "npm:^29.7.0"
-    jest-haste-map: "npm:^29.7.0"
-    jest-message-util: "npm:^29.7.0"
-    jest-regex-util: "npm:^29.6.3"
-    jest-resolve: "npm:^29.7.0"
-    jest-resolve-dependencies: "npm:^29.7.0"
-    jest-runner: "npm:^29.7.0"
-    jest-runtime: "npm:^29.7.0"
-    jest-snapshot: "npm:^29.7.0"
-    jest-util: "npm:^29.7.0"
-    jest-validate: "npm:^29.7.0"
-    jest-watcher: "npm:^29.7.0"
+    jest-changed-files: "npm:30.0.0-alpha.2"
+    jest-config: "npm:30.0.0-alpha.2"
+    jest-haste-map: "npm:30.0.0-alpha.2"
+    jest-message-util: "npm:30.0.0-alpha.2"
+    jest-regex-util: "npm:30.0.0-alpha.2"
+    jest-resolve: "npm:30.0.0-alpha.2"
+    jest-resolve-dependencies: "npm:30.0.0-alpha.2"
+    jest-runner: "npm:30.0.0-alpha.2"
+    jest-runtime: "npm:30.0.0-alpha.2"
+    jest-snapshot: "npm:30.0.0-alpha.2"
+    jest-util: "npm:30.0.0-alpha.2"
+    jest-validate: "npm:30.0.0-alpha.2"
+    jest-watcher: "npm:30.0.0-alpha.2"
     micromatch: "npm:^4.0.4"
-    pretty-format: "npm:^29.7.0"
+    pretty-format: "npm:30.0.0-alpha.2"
     slash: "npm:^3.0.0"
     strip-ansi: "npm:^6.0.0"
   peerDependencies:
@@ -613,7 +613,7 @@ __metadata:
   peerDependenciesMeta:
     node-notifier:
       optional: true
-  checksum: 934f7bf73190f029ac0f96662c85cd276ec460d407baf6b0dbaec2872e157db4d55a7ee0b1c43b18874602f662b37cb973dda469a4e6d88b4e4845b521adeeb2
+  checksum: d294eb65e3d9daedbad42a029096c308a3401b6fb31e9c701166ebda90f21bcba4a6036d01a9df7db260366ca9c6e41d41970258c9b6cfe3f989a71637af4447
   languageName: node
   linkType: hard
 
@@ -626,15 +626,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/environment@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/environment@npm:29.7.0"
+"@jest/environment@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "@jest/environment@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/fake-timers": "npm:^29.7.0"
-    "@jest/types": "npm:^29.6.3"
+    "@jest/fake-timers": "npm:30.0.0-alpha.2"
+    "@jest/types": "npm:30.0.0-alpha.2"
     "@types/node": "npm:*"
-    jest-mock: "npm:^29.7.0"
-  checksum: c7b1b40c618f8baf4d00609022d2afa086d9c6acc706f303a70bb4b67275868f620ad2e1a9efc5edd418906157337cce50589a627a6400bbdf117d351b91ef86
+    jest-mock: "npm:30.0.0-alpha.2"
+  checksum: f98023c6a0e6fedda9ff7d4777675c325f20575e587a0201acb8c3c634f02bae3c7b90c5125c27d1c17a79c9dde6a5ea94e91dbbe613f1b80a2a4c5652a477e8
+  languageName: node
+  linkType: hard
+
+"@jest/expect-utils@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "@jest/expect-utils@npm:30.0.0-alpha.2"
+  dependencies:
+    jest-get-type: "npm:30.0.0-alpha.2"
+  checksum: 52e0f628fbb2b8494b3b2f300924f4cafe500c14404730dfe24d257d6db62e34cd8532d662e2f91cfd4f24ebc73c77393de88111b8d9e8d269c9535be7290b1c
   languageName: node
   linkType: hard
 
@@ -647,51 +656,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/expect@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/expect@npm:29.7.0"
+"@jest/expect@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "@jest/expect@npm:30.0.0-alpha.2"
   dependencies:
-    expect: "npm:^29.7.0"
-    jest-snapshot: "npm:^29.7.0"
-  checksum: b41f193fb697d3ced134349250aed6ccea075e48c4f803159db102b826a4e473397c68c31118259868fd69a5cba70e97e1c26d2c2ff716ca39dc73a2ccec037e
+    expect: "npm:30.0.0-alpha.2"
+    jest-snapshot: "npm:30.0.0-alpha.2"
+  checksum: aaebd02f1253e9b2e848a5ce69ff2c0fe0d5f68971930b91e488b963355a58d663aaddbf0894576df3fc3cbae7f1e9395a22d2e45677c89808042e7b4dc0efed
   languageName: node
   linkType: hard
 
-"@jest/fake-timers@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/fake-timers@npm:29.7.0"
+"@jest/fake-timers@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "@jest/fake-timers@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/types": "npm:^29.6.3"
-    "@sinonjs/fake-timers": "npm:^10.0.2"
+    "@jest/types": "npm:30.0.0-alpha.2"
+    "@sinonjs/fake-timers": "npm:^11.1.0"
     "@types/node": "npm:*"
-    jest-message-util: "npm:^29.7.0"
-    jest-mock: "npm:^29.7.0"
-    jest-util: "npm:^29.7.0"
-  checksum: cf0a8bcda801b28dc2e2b2ba36302200ee8104a45ad7a21e6c234148932f826cb3bc57c8df3b7b815aeea0861d7b6ca6f0d4778f93b9219398ef28749e03595c
+    jest-message-util: "npm:30.0.0-alpha.2"
+    jest-mock: "npm:30.0.0-alpha.2"
+    jest-util: "npm:30.0.0-alpha.2"
+  checksum: 6c8916bfa8c6f63100a41f1f522d4d313615779b66e2e60f4deb832ab00df7b0213a2d1ecbb127ddce25ff0adaaeac83073b9b46500024f471369ec1849a4139
   languageName: node
   linkType: hard
 
-"@jest/globals@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/globals@npm:29.7.0"
+"@jest/globals@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "@jest/globals@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/environment": "npm:^29.7.0"
-    "@jest/expect": "npm:^29.7.0"
-    "@jest/types": "npm:^29.6.3"
-    jest-mock: "npm:^29.7.0"
-  checksum: a385c99396878fe6e4460c43bd7bb0a5cc52befb462cc6e7f2a3810f9e7bcce7cdeb51908fd530391ee452dc856c98baa2c5f5fa8a5b30b071d31ef7f6955cea
+    "@jest/environment": "npm:30.0.0-alpha.2"
+    "@jest/expect": "npm:30.0.0-alpha.2"
+    "@jest/types": "npm:30.0.0-alpha.2"
+    jest-mock: "npm:30.0.0-alpha.2"
+  checksum: fc5519fcae85dfdeddecc7a7cbb8e65771c27bc0553be366ec50427700c0eb6230cb205deaaaecf833db493ad1552ae3cd1d213c98720bdb719a056bccda4542
   languageName: node
   linkType: hard
 
-"@jest/reporters@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/reporters@npm:29.7.0"
+"@jest/reporters@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "@jest/reporters@npm:30.0.0-alpha.2"
   dependencies:
     "@bcoe/v8-coverage": "npm:^0.2.3"
-    "@jest/console": "npm:^29.7.0"
-    "@jest/test-result": "npm:^29.7.0"
-    "@jest/transform": "npm:^29.7.0"
-    "@jest/types": "npm:^29.6.3"
+    "@jest/console": "npm:30.0.0-alpha.2"
+    "@jest/test-result": "npm:30.0.0-alpha.2"
+    "@jest/transform": "npm:30.0.0-alpha.2"
+    "@jest/types": "npm:30.0.0-alpha.2"
     "@jridgewell/trace-mapping": "npm:^0.3.18"
     "@types/node": "npm:*"
     chalk: "npm:^4.0.0"
@@ -704,9 +713,9 @@ __metadata:
     istanbul-lib-report: "npm:^3.0.0"
     istanbul-lib-source-maps: "npm:^4.0.0"
     istanbul-reports: "npm:^3.1.3"
-    jest-message-util: "npm:^29.7.0"
-    jest-util: "npm:^29.7.0"
-    jest-worker: "npm:^29.7.0"
+    jest-message-util: "npm:30.0.0-alpha.2"
+    jest-util: "npm:30.0.0-alpha.2"
+    jest-worker: "npm:30.0.0-alpha.2"
     slash: "npm:^3.0.0"
     string-length: "npm:^4.0.1"
     strip-ansi: "npm:^6.0.0"
@@ -716,7 +725,16 @@ __metadata:
   peerDependenciesMeta:
     node-notifier:
       optional: true
-  checksum: a754402a799541c6e5aff2c8160562525e2a47e7d568f01ebfc4da66522de39cbb809bbb0a841c7052e4270d79214e70aec3c169e4eae42a03bc1a8a20cb9fa2
+  checksum: 8818d1d5dae3a72d0245674500e4bc61ea9056d7daba7b90a82ad289886491379fe955b6b81b58da061a336ee7e8d2d4e55eb070298710e32ca2e4b098f1f083
+  languageName: node
+  linkType: hard
+
+"@jest/schemas@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "@jest/schemas@npm:30.0.0-alpha.2"
+  dependencies:
+    "@sinclair/typebox": "npm:^0.31.0"
+  checksum: 75fd019a177564490a020be90f400a7fdc7b8a4910f3af80329c527723216bcda7edf42c50bbfd0575b6d9875025df1396fc3d9a8c9fb737e8147d6533793c1c
   languageName: node
   linkType: hard
 
@@ -729,61 +747,75 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/source-map@npm:^29.6.3":
-  version: 29.6.3
-  resolution: "@jest/source-map@npm:29.6.3"
+"@jest/source-map@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "@jest/source-map@npm:30.0.0-alpha.2"
   dependencies:
     "@jridgewell/trace-mapping": "npm:^0.3.18"
     callsites: "npm:^3.0.0"
     graceful-fs: "npm:^4.2.9"
-  checksum: a2f177081830a2e8ad3f2e29e20b63bd40bade294880b595acf2fc09ec74b6a9dd98f126a2baa2bf4941acd89b13a4ade5351b3885c224107083a0059b60a219
+  checksum: 9bab4be6419b855f06c15f75f1305a77d46dd9eda89b2adc99d152fd6478fbc6b9a6a5c56485400cc2ac9eef814805203ba97f9c7029ba7507641d9e1bf4aa54
   languageName: node
   linkType: hard
 
-"@jest/test-result@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/test-result@npm:29.7.0"
+"@jest/test-result@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "@jest/test-result@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/console": "npm:^29.7.0"
-    "@jest/types": "npm:^29.6.3"
+    "@jest/console": "npm:30.0.0-alpha.2"
+    "@jest/types": "npm:30.0.0-alpha.2"
     "@types/istanbul-lib-coverage": "npm:^2.0.0"
     collect-v8-coverage: "npm:^1.0.0"
-  checksum: 7de54090e54a674ca173470b55dc1afdee994f2d70d185c80236003efd3fa2b753fff51ffcdda8e2890244c411fd2267529d42c4a50a8303755041ee493e6a04
+  checksum: 711aec5870f14f94883a61f30ed4079ee511518bc059adad3c2427451d841acebdc8f3d79cffa46fed5fd0ecb1214bda09f8e0f4132fdbb8185964f0fd18dc50
   languageName: node
   linkType: hard
 
-"@jest/test-sequencer@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/test-sequencer@npm:29.7.0"
+"@jest/test-sequencer@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "@jest/test-sequencer@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/test-result": "npm:^29.7.0"
+    "@jest/test-result": "npm:30.0.0-alpha.2"
     graceful-fs: "npm:^4.2.9"
-    jest-haste-map: "npm:^29.7.0"
+    jest-haste-map: "npm:30.0.0-alpha.2"
     slash: "npm:^3.0.0"
-  checksum: 593a8c4272797bb5628984486080cbf57aed09c7cfdc0a634e8c06c38c6bef329c46c0016e84555ee55d1cd1f381518cf1890990ff845524c1123720c8c1481b
+  checksum: 02f45c229a5da46f8d70cf4184f41afda78cb76c4815e400ed846b1b1c219d770bafaae6a6c990059ab8c0455fe78e11b485191ae02df0bee146b26dd950d937
   languageName: node
   linkType: hard
 
-"@jest/transform@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/transform@npm:29.7.0"
+"@jest/transform@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "@jest/transform@npm:30.0.0-alpha.2"
   dependencies:
     "@babel/core": "npm:^7.11.6"
-    "@jest/types": "npm:^29.6.3"
+    "@jest/types": "npm:30.0.0-alpha.2"
     "@jridgewell/trace-mapping": "npm:^0.3.18"
     babel-plugin-istanbul: "npm:^6.1.1"
     chalk: "npm:^4.0.0"
     convert-source-map: "npm:^2.0.0"
     fast-json-stable-stringify: "npm:^2.1.0"
     graceful-fs: "npm:^4.2.9"
-    jest-haste-map: "npm:^29.7.0"
-    jest-regex-util: "npm:^29.6.3"
-    jest-util: "npm:^29.7.0"
+    jest-haste-map: "npm:30.0.0-alpha.2"
+    jest-regex-util: "npm:30.0.0-alpha.2"
+    jest-util: "npm:30.0.0-alpha.2"
     micromatch: "npm:^4.0.4"
     pirates: "npm:^4.0.4"
     slash: "npm:^3.0.0"
-    write-file-atomic: "npm:^4.0.2"
-  checksum: 7f4a7f73dcf45dfdf280c7aa283cbac7b6e5a904813c3a93ead7e55873761fc20d5c4f0191d2019004fac6f55f061c82eb3249c2901164ad80e362e7a7ede5a6
+    write-file-atomic: "npm:^5.0.0"
+  checksum: d14d2fe07725ce01089d91be7f45d3347f416f3b36f738717e37ffd3fa98fda98ec6703ad23fc442f86e0fd198455d5f4e383bdd73a4ba0c0538f3ddde461379
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "@jest/types@npm:30.0.0-alpha.2"
+  dependencies:
+    "@jest/schemas": "npm:30.0.0-alpha.2"
+    "@types/istanbul-lib-coverage": "npm:^2.0.0"
+    "@types/istanbul-reports": "npm:^3.0.0"
+    "@types/node": "npm:*"
+    "@types/yargs": "npm:^17.0.8"
+    chalk: "npm:^4.0.0"
+  checksum: eb73c38e6563069b983a61dce74540bc8e181bf9569b35bf29219aab85c79f22cbf4f9749fe6d4364f3b1fb34a275afd778f54ab097df39015e528bb4c3f4a63
   languageName: node
   linkType: hard
 
@@ -922,10 +954,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pkgr/utils@npm:^2.3.1":
+  version: 2.4.2
+  resolution: "@pkgr/utils@npm:2.4.2"
+  dependencies:
+    cross-spawn: "npm:^7.0.3"
+    fast-glob: "npm:^3.3.0"
+    is-glob: "npm:^4.0.3"
+    open: "npm:^9.1.0"
+    picocolors: "npm:^1.0.0"
+    tslib: "npm:^2.6.0"
+  checksum: 7c3e68f6405a1d4c51f418d8d580e71d7bade2683d5db07e8413d8e57f7e389047eda44a2341f77a1b3085895fca7676a9d45e8812a58312524f8c4c65d501be
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.27.8":
   version: 0.27.8
   resolution: "@sinclair/typebox@npm:0.27.8"
   checksum: ef6351ae073c45c2ac89494dbb3e1f87cc60a93ce4cde797b782812b6f97da0d620ae81973f104b43c9b7eaa789ad20ba4f6a1359f1cc62f63729a55a7d22d4e
+  languageName: node
+  linkType: hard
+
+"@sinclair/typebox@npm:^0.31.0":
+  version: 0.31.28
+  resolution: "@sinclair/typebox@npm:0.31.28"
+  checksum: b3125e370e040738cc42c1ca5210bab44cdfc220b156ccd876f5fa1697ff6fe3ea110190c135e268e41d203d6481750b350add33e79b9874da68dc3a4d601f5a
   languageName: node
   linkType: hard
 
@@ -938,12 +991,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/fake-timers@npm:^10.0.2":
-  version: 10.3.0
-  resolution: "@sinonjs/fake-timers@npm:10.3.0"
+"@sinonjs/fake-timers@npm:^11.1.0":
+  version: 11.2.2
+  resolution: "@sinonjs/fake-timers@npm:11.2.2"
   dependencies:
     "@sinonjs/commons": "npm:^3.0.0"
-  checksum: 2e2fb6cc57f227912814085b7b01fede050cd4746ea8d49a1e44d5a0e56a804663b0340ae2f11af7559ea9bf4d087a11f2f646197a660ea3cb04e19efc04aa63
+  checksum: a4218efa6fdafda622d02d4c0a6ab7df3641cb038bb0b14f0a3ee56f50c95aab4f1ab2d7798ce928b40c6fc1839465a558c9393a77e4dca879e1b2f8d60d8136
   languageName: node
   linkType: hard
 
@@ -1155,15 +1208,6 @@ __metadata:
   dependencies:
     "@babel/types": "npm:^7.20.7"
   checksum: e76cb4974c7740fd61311152dc497e7b05c1c46ba554aab875544ab0a7457f343cafcad34ba8fb2ff543ab0e012ef2d3fa0c13f1a4e9a4cd9c4c703c7a2a8d62
-  languageName: node
-  linkType: hard
-
-"@types/graceful-fs@npm:^4.1.3":
-  version: 4.1.9
-  resolution: "@types/graceful-fs@npm:4.1.9"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 235d2fc69741448e853333b7c3d1180a966dd2b8972c8cbcd6b2a0c6cd7f8d582ab2b8e58219dbc62cce8f1b40aa317ff78ea2201cdd8249da5025adebed6f0b
   languageName: node
   linkType: hard
 
@@ -1667,20 +1711,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-jest@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "babel-jest@npm:29.7.0"
+"babel-jest@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "babel-jest@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/transform": "npm:^29.7.0"
+    "@jest/transform": "npm:30.0.0-alpha.2"
     "@types/babel__core": "npm:^7.1.14"
     babel-plugin-istanbul: "npm:^6.1.1"
-    babel-preset-jest: "npm:^29.6.3"
+    babel-preset-jest: "npm:30.0.0-alpha.2"
     chalk: "npm:^4.0.0"
     graceful-fs: "npm:^4.2.9"
     slash: "npm:^3.0.0"
   peerDependencies:
-    "@babel/core": ^7.8.0
-  checksum: 2eda9c1391e51936ca573dd1aedfee07b14c59b33dbe16ef347873ddd777bcf6e2fc739681e9e9661ab54ef84a3109a03725be2ac32cd2124c07ea4401cbe8c1
+    "@babel/core": ^7.11.0
+  checksum: 0ce7d4ecf1b3695e13f5249bab63d600743836f581fc84f31dbec95b73b34cf32ed125c3b11e9c485eb58dc339d696fea186c7cf057abdad6228b73a0db9a831
   languageName: node
   linkType: hard
 
@@ -1697,15 +1741,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-jest-hoist@npm:^29.6.3":
-  version: 29.6.3
-  resolution: "babel-plugin-jest-hoist@npm:29.6.3"
+"babel-plugin-jest-hoist@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "babel-plugin-jest-hoist@npm:30.0.0-alpha.2"
   dependencies:
     "@babel/template": "npm:^7.3.3"
     "@babel/types": "npm:^7.3.3"
     "@types/babel__core": "npm:^7.1.14"
     "@types/babel__traverse": "npm:^7.0.6"
-  checksum: 7e6451caaf7dce33d010b8aafb970e62f1b0c0b57f4978c37b0d457bbcf0874d75a395a102daf0bae0bd14eafb9f6e9a165ee5e899c0a4f1f3bb2e07b304ed2e
+  checksum: 1c91cb7c52625e0da034b7a056204593dbfcfca648ed29b9ec597edca9fe1c9863a1bed5ed43d5b5aecd1c68a362673f109bf484fc7d704a025e138c0536d45c
   languageName: node
   linkType: hard
 
@@ -1731,15 +1775,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-preset-jest@npm:^29.6.3":
-  version: 29.6.3
-  resolution: "babel-preset-jest@npm:29.6.3"
+"babel-preset-jest@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "babel-preset-jest@npm:30.0.0-alpha.2"
   dependencies:
-    babel-plugin-jest-hoist: "npm:^29.6.3"
+    babel-plugin-jest-hoist: "npm:30.0.0-alpha.2"
     babel-preset-current-node-syntax: "npm:^1.0.0"
   peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: ec5fd0276b5630b05f0c14bb97cc3815c6b31600c683ebb51372e54dcb776cff790bdeeabd5b8d01ede375a040337ccbf6a3ccd68d3a34219125945e167ad943
+    "@babel/core": ^7.11.0
+  checksum: 563a6b7ba472e1880e92e72b2466a20e831fa6d97f116db292993bbcd12fb4bdaf851e1875f6f66dfe359630599f0855c0e30c786009993673eada3174669876
   languageName: node
   linkType: hard
 
@@ -1747,6 +1791,22 @@ __metadata:
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
   checksum: 9308baf0a7e4838a82bbfd11e01b1cb0f0cf2893bc1676c27c2a8c0e70cbae1c59120c3268517a8ae7fb6376b4639ef81ca22582611dbee4ed28df945134aaee
+  languageName: node
+  linkType: hard
+
+"big-integer@npm:^1.6.44":
+  version: 1.6.52
+  resolution: "big-integer@npm:1.6.52"
+  checksum: 9604224b4c2ab3c43c075d92da15863077a9f59e5d4205f4e7e76acd0cd47e8d469ec5e5dba8d9b32aa233951893b29329ca56ac80c20ce094b4a647a66abae0
+  languageName: node
+  linkType: hard
+
+"bplist-parser@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "bplist-parser@npm:0.2.0"
+  dependencies:
+    big-integer: "npm:^1.6.44"
+  checksum: ce79c69e0f6efe506281e7c84e3712f7d12978991675b6e3a58a295b16f13ca81aa9b845c335614a545e0af728c8311b6aa3142af76ba1cb616af9bbac5c4a9f
   languageName: node
   linkType: hard
 
@@ -1805,6 +1865,15 @@ __metadata:
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
   checksum: 124fff9d66d691a86d3b062eff4663fe437a9d9ee4b47b1b9e97f5a5d14f6d5399345db80f796827be7c95e70a8e765dd404b7c3ff3b3324f98e9b0c8826cc34
+  languageName: node
+  linkType: hard
+
+"bundle-name@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "bundle-name@npm:3.0.0"
+  dependencies:
+    run-applescript: "npm:^5.0.0"
+  checksum: 57bc7f8b025d83961b04db2f1eff6a87f2363c2891f3542a4b82471ff8ebb5d484af48e9784fcdb28ef1d48bb01f03d891966dc3ef58758e46ea32d750ce40f8
   languageName: node
   linkType: hard
 
@@ -1918,6 +1987,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ci-info@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "ci-info@npm:4.0.0"
+  checksum: ecc003e5b60580bd081d83dd61d398ddb8607537f916313e40af4667f9c92a1243bd8e8a591a5aa78e418afec245dbe8e90a0e26e39ca0825129a99b978dd3f9
+  languageName: node
+  linkType: hard
+
 "cjs-module-lexer@npm:^1.0.0":
   version: 1.2.3
   resolution: "cjs-module-lexer@npm:1.2.3"
@@ -2003,23 +2079,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-jest@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "create-jest@npm:29.7.0"
-  dependencies:
-    "@jest/types": "npm:^29.6.3"
-    chalk: "npm:^4.0.0"
-    exit: "npm:^0.1.2"
-    graceful-fs: "npm:^4.2.9"
-    jest-config: "npm:^29.7.0"
-    jest-util: "npm:^29.7.0"
-    prompts: "npm:^2.0.1"
-  bin:
-    create-jest: bin/create-jest.js
-  checksum: e7e54c280692470d3398f62a6238fd396327e01c6a0757002833f06d00afc62dd7bfe04ff2b9cd145264460e6b4d1eb8386f2925b7e567f97939843b7b0e812f
-  languageName: node
-  linkType: hard
-
 "create-require@npm:^1.1.0":
   version: 1.1.1
   resolution: "create-require@npm:1.1.1"
@@ -2089,6 +2148,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"default-browser-id@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "default-browser-id@npm:3.0.0"
+  dependencies:
+    bplist-parser: "npm:^0.2.0"
+    untildify: "npm:^4.0.0"
+  checksum: 8db3ab882eb3e1e8b59d84c8641320e6c66d8eeb17eb4bb848b7dd549b1e6fd313988e4a13542e95fbaeff03f6e9dedc5ad191ad4df7996187753eb0d45c00b7
+  languageName: node
+  linkType: hard
+
+"default-browser@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "default-browser@npm:4.0.0"
+  dependencies:
+    bundle-name: "npm:^3.0.0"
+    default-browser-id: "npm:^3.0.0"
+    execa: "npm:^7.1.1"
+    titleize: "npm:^3.0.0"
+  checksum: 7c8848badc139ecf9d878e562bc4e7ab4301e51ba120b24d8dcb14739c30152115cc612065ac3ab73c02aace4afa29db5a044257b2f0cf234f16e3a58f6c925e
+  languageName: node
+  linkType: hard
+
 "define-data-property@npm:^1.0.1, define-data-property@npm:^1.1.1":
   version: 1.1.1
   resolution: "define-data-property@npm:1.1.1"
@@ -2097,6 +2178,13 @@ __metadata:
     gopd: "npm:^1.0.1"
     has-property-descriptors: "npm:^1.0.0"
   checksum: 77ef6e0bceb515e05b5913ab635a84d537cee84f8a7c37c77fdcb31fc5b80f6dbe81b33375e4b67d96aa04e6a0d8d4ea099e431d83f089af8d93adfb584bcb94
+  languageName: node
+  linkType: hard
+
+"define-lazy-prop@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "define-lazy-prop@npm:3.0.0"
+  checksum: 5ab0b2bf3fa58b3a443140bbd4cd3db1f91b985cc8a246d330b9ac3fc0b6a325a6d82bddc0b055123d745b3f9931afeea74a5ec545439a1630b9c8512b0eeb49
   languageName: node
   linkType: hard
 
@@ -2115,6 +2203,13 @@ __metadata:
   version: 3.1.0
   resolution: "detect-newline@npm:3.1.0"
   checksum: c38cfc8eeb9fda09febb44bcd85e467c970d4e3bf526095394e5a4f18bc26dd0cf6b22c69c1fa9969261521c593836db335c2795218f6d781a512aea2fb8209d
+  languageName: node
+  linkType: hard
+
+"diff-sequences@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "diff-sequences@npm:30.0.0-alpha.2"
+  checksum: ecddcd99476cc190eaad7f5b3267bee054bb8c2511b5fa41954c8b7ded74f6d94294e1b5292644b04a8e0177c79aa26fd901e6737c5264333db4b748eb94dfb3
   languageName: node
   linkType: hard
 
@@ -2495,6 +2590,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"execa@npm:^7.1.1":
+  version: 7.2.0
+  resolution: "execa@npm:7.2.0"
+  dependencies:
+    cross-spawn: "npm:^7.0.3"
+    get-stream: "npm:^6.0.1"
+    human-signals: "npm:^4.3.0"
+    is-stream: "npm:^3.0.0"
+    merge-stream: "npm:^2.0.0"
+    npm-run-path: "npm:^5.1.0"
+    onetime: "npm:^6.0.0"
+    signal-exit: "npm:^3.0.7"
+    strip-final-newline: "npm:^3.0.0"
+  checksum: 098cd6a1bc26d509e5402c43f4971736450b84d058391820c6f237aeec6436963e006fd8423c9722f148c53da86aa50045929c7278b5522197dff802d10f9885
+  languageName: node
+  linkType: hard
+
 "exit@npm:^0.1.2":
   version: 0.1.2
   resolution: "exit@npm:0.1.2"
@@ -2502,7 +2614,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:^29.0.0, expect@npm:^29.7.0":
+"expect@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "expect@npm:30.0.0-alpha.2"
+  dependencies:
+    "@jest/expect-utils": "npm:30.0.0-alpha.2"
+    jest-get-type: "npm:30.0.0-alpha.2"
+    jest-matcher-utils: "npm:30.0.0-alpha.2"
+    jest-message-util: "npm:30.0.0-alpha.2"
+    jest-util: "npm:30.0.0-alpha.2"
+  checksum: e407d47bf504749b71f912e2eb6fd0abe4fda6700ee43aa81f164c9346fb19c098e6d19682a088c955b94d690fbfe657df668f233d78ef143e848f45bf6ae534
+  languageName: node
+  linkType: hard
+
+"expect@npm:^29.0.0":
   version: 29.7.0
   resolution: "expect@npm:29.7.0"
   dependencies:
@@ -2539,6 +2664,19 @@ __metadata:
     merge2: "npm:^1.3.0"
     micromatch: "npm:^4.0.4"
   checksum: b68431128fb6ce4b804c5f9622628426d990b66c75b21c0d16e3d80e2d1398bf33f7e1724e66a2e3f299285dcf5b8d745b122d0304e7dd66f5231081f33ec67c
+  languageName: node
+  linkType: hard
+
+"fast-glob@npm:^3.3.0":
+  version: 3.3.2
+  resolution: "fast-glob@npm:3.3.2"
+  dependencies:
+    "@nodelib/fs.stat": "npm:^2.0.2"
+    "@nodelib/fs.walk": "npm:^1.2.3"
+    glob-parent: "npm:^5.1.2"
+    merge2: "npm:^1.3.0"
+    micromatch: "npm:^4.0.4"
+  checksum: 42baad7b9cd40b63e42039132bde27ca2cb3a4950d0a0f9abe4639ea1aa9d3e3b40f98b1fe31cbc0cc17b664c9ea7447d911a152fa34ec5b72977b125a6fc845
   languageName: node
   linkType: hard
 
@@ -2752,7 +2890,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^6.0.0":
+"get-stream@npm:^6.0.0, get-stream@npm:^6.0.1":
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: 49825d57d3fd6964228e6200a58169464b8e8970489b3acdc24906c782fb7f01f9f56f8e6653c4a50713771d6658f7cfe051e5eb8c12e334138c9c918b296341
@@ -2988,6 +3126,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"human-signals@npm:^4.3.0":
+  version: 4.3.1
+  resolution: "human-signals@npm:4.3.1"
+  checksum: 40498b33fe139f5cc4ef5d2f95eb1803d6318ac1b1c63eaf14eeed5484d26332c828de4a5a05676b6c83d7b9e57727c59addb4b1dea19cb8d71e83689e5b336c
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -3144,6 +3289,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-docker@npm:^2.0.0":
+  version: 2.2.1
+  resolution: "is-docker@npm:2.2.1"
+  bin:
+    is-docker: cli.js
+  checksum: e828365958d155f90c409cdbe958f64051d99e8aedc2c8c4cd7c89dcf35329daed42f7b99346f7828df013e27deb8f721cf9408ba878c76eb9e8290235fbcdcc
+  languageName: node
+  linkType: hard
+
+"is-docker@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-docker@npm:3.0.0"
+  bin:
+    is-docker: cli.js
+  checksum: d2c4f8e6d3e34df75a5defd44991b6068afad4835bb783b902fa12d13ebdb8f41b2a199dcb0b5ed2cb78bfee9e4c0bbdb69c2d9646f4106464674d3e697a5856
+  languageName: node
+  linkType: hard
+
 "is-extglob@npm:^2.1.1":
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
@@ -3171,6 +3334,17 @@ __metadata:
   dependencies:
     is-extglob: "npm:^2.1.1"
   checksum: 17fb4014e22be3bbecea9b2e3a76e9e34ff645466be702f1693e8f1ee1adac84710d0be0bd9f967d6354036fd51ab7c2741d954d6e91dae6bb69714de92c197a
+  languageName: node
+  linkType: hard
+
+"is-inside-container@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-inside-container@npm:1.0.0"
+  dependencies:
+    is-docker: "npm:^3.0.0"
+  bin:
+    is-inside-container: cli.js
+  checksum: a8efb0e84f6197e6ff5c64c52890fa9acb49b7b74fed4da7c95383965da6f0fa592b4dbd5e38a79f87fc108196937acdbcd758fcefc9b140e479b39ce1fcd1cd
   languageName: node
   linkType: hard
 
@@ -3237,6 +3411,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-stream@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-stream@npm:3.0.0"
+  checksum: eb2f7127af02ee9aa2a0237b730e47ac2de0d4e76a4a905a50a11557f2339df5765eaea4ceb8029f1efa978586abe776908720bfcb1900c20c6ec5145f6f29d8
+  languageName: node
+  linkType: hard
+
 "is-string@npm:^1.0.5, is-string@npm:^1.0.7":
   version: 1.0.7
   resolution: "is-string@npm:1.0.7"
@@ -3270,6 +3451,15 @@ __metadata:
   dependencies:
     call-bind: "npm:^1.0.2"
   checksum: 1545c5d172cb690c392f2136c23eec07d8d78a7f57d0e41f10078aa4f5daf5d7f57b6513a67514ab4f073275ad00c9822fc8935e00229d0a2089e1c02685d4b1
+  languageName: node
+  linkType: hard
+
+"is-wsl@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "is-wsl@npm:2.2.0"
+  dependencies:
+    is-docker: "npm:^2.0.0"
+  checksum: a6fa2d370d21be487c0165c7a440d567274fbba1a817f2f0bfa41cc5e3af25041d84267baa22df66696956038a43973e72fca117918c91431920bdef490fa25e
   languageName: node
   linkType: hard
 
@@ -3372,59 +3562,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-changed-files@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-changed-files@npm:29.7.0"
+"jest-changed-files@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-changed-files@npm:30.0.0-alpha.2"
   dependencies:
     execa: "npm:^5.0.0"
-    jest-util: "npm:^29.7.0"
+    jest-util: "npm:30.0.0-alpha.2"
     p-limit: "npm:^3.1.0"
-  checksum: e071384d9e2f6bb462231ac53f29bff86f0e12394c1b49ccafbad225ce2ab7da226279a8a94f421949920bef9be7ef574fd86aee22e8adfa149be73554ab828b
+  checksum: 440513d1420779aa5b2d41aa24a0302d7787871c90c7b36c32286b8bcec6c21408831cd7b878e16276987a01652e50c9b1abd4216224733d0f3db01ab704f9bc
   languageName: node
   linkType: hard
 
-"jest-circus@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-circus@npm:29.7.0"
+"jest-circus@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-circus@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/environment": "npm:^29.7.0"
-    "@jest/expect": "npm:^29.7.0"
-    "@jest/test-result": "npm:^29.7.0"
-    "@jest/types": "npm:^29.6.3"
+    "@jest/environment": "npm:30.0.0-alpha.2"
+    "@jest/expect": "npm:30.0.0-alpha.2"
+    "@jest/test-result": "npm:30.0.0-alpha.2"
+    "@jest/types": "npm:30.0.0-alpha.2"
     "@types/node": "npm:*"
     chalk: "npm:^4.0.0"
     co: "npm:^4.6.0"
     dedent: "npm:^1.0.0"
     is-generator-fn: "npm:^2.0.0"
-    jest-each: "npm:^29.7.0"
-    jest-matcher-utils: "npm:^29.7.0"
-    jest-message-util: "npm:^29.7.0"
-    jest-runtime: "npm:^29.7.0"
-    jest-snapshot: "npm:^29.7.0"
-    jest-util: "npm:^29.7.0"
+    jest-each: "npm:30.0.0-alpha.2"
+    jest-matcher-utils: "npm:30.0.0-alpha.2"
+    jest-message-util: "npm:30.0.0-alpha.2"
+    jest-runtime: "npm:30.0.0-alpha.2"
+    jest-snapshot: "npm:30.0.0-alpha.2"
+    jest-util: "npm:30.0.0-alpha.2"
     p-limit: "npm:^3.1.0"
-    pretty-format: "npm:^29.7.0"
+    pretty-format: "npm:30.0.0-alpha.2"
     pure-rand: "npm:^6.0.0"
     slash: "npm:^3.0.0"
     stack-utils: "npm:^2.0.3"
-  checksum: 8d15344cf7a9f14e926f0deed64ed190c7a4fa1ed1acfcd81e4cc094d3cc5bf7902ebb7b874edc98ada4185688f90c91e1747e0dfd7ac12463b097968ae74b5e
+  checksum: ff34e30752366de0563383e2e9aadae74ba443068cbe58b1fb6f62d1440ccc425a9a8b254d6c79dbae059efca75466783d707ae5e03c48a7d52d6e1844957bc0
   languageName: node
   linkType: hard
 
-"jest-cli@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-cli@npm:29.7.0"
+"jest-cli@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-cli@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/core": "npm:^29.7.0"
-    "@jest/test-result": "npm:^29.7.0"
-    "@jest/types": "npm:^29.6.3"
+    "@jest/core": "npm:30.0.0-alpha.2"
+    "@jest/test-result": "npm:30.0.0-alpha.2"
+    "@jest/types": "npm:30.0.0-alpha.2"
     chalk: "npm:^4.0.0"
-    create-jest: "npm:^29.7.0"
     exit: "npm:^0.1.2"
     import-local: "npm:^3.0.2"
-    jest-config: "npm:^29.7.0"
-    jest-util: "npm:^29.7.0"
-    jest-validate: "npm:^29.7.0"
+    jest-config: "npm:30.0.0-alpha.2"
+    jest-util: "npm:30.0.0-alpha.2"
+    jest-validate: "npm:30.0.0-alpha.2"
     yargs: "npm:^17.3.1"
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -3433,34 +3622,34 @@ __metadata:
       optional: true
   bin:
     jest: bin/jest.js
-  checksum: a658fd55050d4075d65c1066364595962ead7661711495cfa1dfeecf3d6d0a8ffec532f3dbd8afbb3e172dd5fd2fb2e813c5e10256e7cf2fea766314942fb43a
+  checksum: 00180ef91c94e1df471c41c38512b3a37e56c857b691a72f965fc35e8db0e6733454b88436e6c6196c080659463e12508f300ae46d02882bd18109ff11b03dc1
   languageName: node
   linkType: hard
 
-"jest-config@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-config@npm:29.7.0"
+"jest-config@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-config@npm:30.0.0-alpha.2"
   dependencies:
     "@babel/core": "npm:^7.11.6"
-    "@jest/test-sequencer": "npm:^29.7.0"
-    "@jest/types": "npm:^29.6.3"
-    babel-jest: "npm:^29.7.0"
+    "@jest/test-sequencer": "npm:30.0.0-alpha.2"
+    "@jest/types": "npm:30.0.0-alpha.2"
+    babel-jest: "npm:30.0.0-alpha.2"
     chalk: "npm:^4.0.0"
-    ci-info: "npm:^3.2.0"
+    ci-info: "npm:^4.0.0"
     deepmerge: "npm:^4.2.2"
     glob: "npm:^7.1.3"
     graceful-fs: "npm:^4.2.9"
-    jest-circus: "npm:^29.7.0"
-    jest-environment-node: "npm:^29.7.0"
-    jest-get-type: "npm:^29.6.3"
-    jest-regex-util: "npm:^29.6.3"
-    jest-resolve: "npm:^29.7.0"
-    jest-runner: "npm:^29.7.0"
-    jest-util: "npm:^29.7.0"
-    jest-validate: "npm:^29.7.0"
+    jest-circus: "npm:30.0.0-alpha.2"
+    jest-environment-node: "npm:30.0.0-alpha.2"
+    jest-get-type: "npm:30.0.0-alpha.2"
+    jest-regex-util: "npm:30.0.0-alpha.2"
+    jest-resolve: "npm:30.0.0-alpha.2"
+    jest-runner: "npm:30.0.0-alpha.2"
+    jest-util: "npm:30.0.0-alpha.2"
+    jest-validate: "npm:30.0.0-alpha.2"
     micromatch: "npm:^4.0.4"
     parse-json: "npm:^5.2.0"
-    pretty-format: "npm:^29.7.0"
+    pretty-format: "npm:30.0.0-alpha.2"
     slash: "npm:^3.0.0"
     strip-json-comments: "npm:^3.1.1"
   peerDependencies:
@@ -3471,7 +3660,19 @@ __metadata:
       optional: true
     ts-node:
       optional: true
-  checksum: bab23c2eda1fff06e0d104b00d6adfb1d1aabb7128441899c9bff2247bd26710b050a5364281ce8d52b46b499153bf7e3ee88b19831a8f3451f1477a0246a0f1
+  checksum: 6a007f8156b795c54d23d2c46142d4f19b4f009668c94601099e46984e4dbe71ec19578fff348f6c514b906c1744a66889cb0d5efff0298593ae857a846c6127
+  languageName: node
+  linkType: hard
+
+"jest-diff@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-diff@npm:30.0.0-alpha.2"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    diff-sequences: "npm:30.0.0-alpha.2"
+    jest-get-type: "npm:30.0.0-alpha.2"
+    pretty-format: "npm:30.0.0-alpha.2"
+  checksum: 3999d9e66197e9f0c4eb82e5859ee7b10725f4b632daf73812c77ec1d6f37371046b602def0ab2a41047f2320d80655edcb6a079bc6d19dcfec93f91b040f8fc
   languageName: node
   linkType: hard
 
@@ -3487,39 +3688,46 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-docblock@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-docblock@npm:29.7.0"
+"jest-docblock@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-docblock@npm:30.0.0-alpha.2"
   dependencies:
     detect-newline: "npm:^3.0.0"
-  checksum: d932a8272345cf6b6142bb70a2bb63e0856cc0093f082821577ea5bdf4643916a98744dfc992189d2b1417c38a11fa42466f6111526bc1fb81366f56410f3be9
+  checksum: 731bb6af766055e63738238d4383ff5df37109393674e4028512fe16bc800a0050580b8808777565dba5e7a41471d84b305d56882689c8007fc6591e235447e4
   languageName: node
   linkType: hard
 
-"jest-each@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-each@npm:29.7.0"
+"jest-each@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-each@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/types": "npm:^29.6.3"
+    "@jest/types": "npm:30.0.0-alpha.2"
     chalk: "npm:^4.0.0"
-    jest-get-type: "npm:^29.6.3"
-    jest-util: "npm:^29.7.0"
-    pretty-format: "npm:^29.7.0"
-  checksum: f7f9a90ebee80cc688e825feceb2613627826ac41ea76a366fa58e669c3b2403d364c7c0a74d862d469b103c843154f8456d3b1c02b487509a12afa8b59edbb4
+    jest-get-type: "npm:30.0.0-alpha.2"
+    jest-util: "npm:30.0.0-alpha.2"
+    pretty-format: "npm:30.0.0-alpha.2"
+  checksum: 1135845f9457d2f9a6b6008f19a62b7bb051219f32172166a82f083c3052352d45f2ddf4ea6486d3e20251c6d838e8b8e6558fc53206623c5d45d48bd6966837
   languageName: node
   linkType: hard
 
-"jest-environment-node@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-environment-node@npm:29.7.0"
+"jest-environment-node@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-environment-node@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/environment": "npm:^29.7.0"
-    "@jest/fake-timers": "npm:^29.7.0"
-    "@jest/types": "npm:^29.6.3"
+    "@jest/environment": "npm:30.0.0-alpha.2"
+    "@jest/fake-timers": "npm:30.0.0-alpha.2"
+    "@jest/types": "npm:30.0.0-alpha.2"
     "@types/node": "npm:*"
-    jest-mock: "npm:^29.7.0"
-    jest-util: "npm:^29.7.0"
-  checksum: 61f04fec077f8b1b5c1a633e3612fc0c9aa79a0ab7b05600683428f1e01a4d35346c474bde6f439f9fcc1a4aa9a2861ff852d079a43ab64b02105d1004b2592b
+    jest-mock: "npm:30.0.0-alpha.2"
+    jest-util: "npm:30.0.0-alpha.2"
+  checksum: e9b57ee880055e7a5b8fbd9d2093ffcfed03068213dddb75906b8e8427c4463883383ca9a6e12fc81a5923a4ebfab46712075fc11696a2fd42ab419f40a1bcc3
+  languageName: node
+  linkType: hard
+
+"jest-get-type@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-get-type@npm:30.0.0-alpha.2"
+  checksum: 1b597bb8bfc3074c870a2ac354c689cd5fc3b23be8d25633f01b70538d9dcd83ae8a023514cee0b830989b97b5a525f85743edb0147efe2491bf841cc014f5b0
   languageName: node
   linkType: hard
 
@@ -3530,36 +3738,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-haste-map@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-haste-map@npm:29.7.0"
+"jest-haste-map@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-haste-map@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/types": "npm:^29.6.3"
-    "@types/graceful-fs": "npm:^4.1.3"
+    "@jest/types": "npm:30.0.0-alpha.2"
     "@types/node": "npm:*"
     anymatch: "npm:^3.0.3"
     fb-watchman: "npm:^2.0.0"
     fsevents: "npm:^2.3.2"
     graceful-fs: "npm:^4.2.9"
-    jest-regex-util: "npm:^29.6.3"
-    jest-util: "npm:^29.7.0"
-    jest-worker: "npm:^29.7.0"
+    jest-regex-util: "npm:30.0.0-alpha.2"
+    jest-util: "npm:30.0.0-alpha.2"
+    jest-worker: "npm:30.0.0-alpha.2"
     micromatch: "npm:^4.0.4"
     walker: "npm:^1.0.8"
   dependenciesMeta:
     fsevents:
       optional: true
-  checksum: 2683a8f29793c75a4728787662972fedd9267704c8f7ef9d84f2beed9a977f1cf5e998c07b6f36ba5603f53cb010c911fe8cd0ac9886e073fe28ca66beefd30c
+  checksum: fa5eb311a509a94ed5df4c92bf3ba61e0ffbe90a5d3f4ad199e9479939dc40e034bb9c711a884a0e287b15a68dc764fd5c15e7dd651a760caafbfae5d18c3a59
   languageName: node
   linkType: hard
 
-"jest-leak-detector@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-leak-detector@npm:29.7.0"
+"jest-leak-detector@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-leak-detector@npm:30.0.0-alpha.2"
   dependencies:
-    jest-get-type: "npm:^29.6.3"
-    pretty-format: "npm:^29.7.0"
-  checksum: 71bb9f77fc489acb842a5c7be030f2b9acb18574dc9fb98b3100fc57d422b1abc55f08040884bd6e6dbf455047a62f7eaff12aa4058f7cbdc11558718ca6a395
+    jest-get-type: "npm:30.0.0-alpha.2"
+    pretty-format: "npm:30.0.0-alpha.2"
+  checksum: f02a4c31fba9e3468a65e8caa4dfe7c1a4060f8ebdfbbe8fe4ce3c707f2da6e9e2975257f7c5f9942ef14147e8526a740b639f724036c4d6db76d4750e7e5c92
+  languageName: node
+  linkType: hard
+
+"jest-matcher-utils@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-matcher-utils@npm:30.0.0-alpha.2"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    jest-diff: "npm:30.0.0-alpha.2"
+    jest-get-type: "npm:30.0.0-alpha.2"
+    pretty-format: "npm:30.0.0-alpha.2"
+  checksum: 2932c7ba36e2326b349a02dee9e693e28ca146802aeb467583d4624319527be9cc279d6eb34e259e72623a48ae026366ed0a7444f9e24976c87a63c62b9aacb2
   languageName: node
   linkType: hard
 
@@ -3572,6 +3791,23 @@ __metadata:
     jest-get-type: "npm:^29.6.3"
     pretty-format: "npm:^29.7.0"
   checksum: 0d0e70b28fa5c7d4dce701dc1f46ae0922102aadc24ed45d594dd9b7ae0a8a6ef8b216718d1ab79e451291217e05d4d49a82666e1a3cc2b428b75cd9c933244e
+  languageName: node
+  linkType: hard
+
+"jest-message-util@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-message-util@npm:30.0.0-alpha.2"
+  dependencies:
+    "@babel/code-frame": "npm:^7.12.13"
+    "@jest/types": "npm:30.0.0-alpha.2"
+    "@types/stack-utils": "npm:^2.0.0"
+    chalk: "npm:^4.0.0"
+    graceful-fs: "npm:^4.2.9"
+    micromatch: "npm:^4.0.4"
+    pretty-format: "npm:30.0.0-alpha.2"
+    slash: "npm:^3.0.0"
+    stack-utils: "npm:^2.0.3"
+  checksum: 1ed2164493a61a3f75ae8431a76f22638fd13473e0587a9effb27a5a01765572fd4fbe31502ea2e9e55a4f24dcc537c2633b9f5a3f5188f86976ad0f5bd00f20
   languageName: node
   linkType: hard
 
@@ -3592,14 +3828,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-mock@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-mock@npm:29.7.0"
+"jest-mock@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-mock@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/types": "npm:^29.6.3"
+    "@jest/types": "npm:30.0.0-alpha.2"
     "@types/node": "npm:*"
-    jest-util: "npm:^29.7.0"
-  checksum: 7b9f8349ee87695a309fe15c46a74ab04c853369e5c40952d68061d9dc3159a0f0ed73e215f81b07ee97a9faaf10aebe5877a9d6255068a0977eae6a9ff1d5ac
+    jest-util: "npm:30.0.0-alpha.2"
+  checksum: 966b68758f605f1c4e24f8cce5311d959e62a61537dbd2dae942fe28d828324554341b9244bc5ecb84b2019a3d6d1a1b69143cc34b62c6bef6047b6beb4d9ec1
   languageName: node
   linkType: hard
 
@@ -3615,124 +3851,139 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-regex-util@npm:^29.6.3":
-  version: 29.6.3
-  resolution: "jest-regex-util@npm:29.6.3"
-  checksum: 4e33fb16c4f42111159cafe26397118dcfc4cf08bc178a67149fb05f45546a91928b820894572679d62559839d0992e21080a1527faad65daaae8743a5705a3b
+"jest-regex-util@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-regex-util@npm:30.0.0-alpha.2"
+  checksum: 18fb7bcd30318f1a4b7bd390b87e6223d8fe60fe0694ec5ad56f44eb731504a00872bb2ebc982f08f45f25a873de9e566b634e2f28d3cb6798e226e1034b118d
   languageName: node
   linkType: hard
 
-"jest-resolve-dependencies@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-resolve-dependencies@npm:29.7.0"
+"jest-resolve-dependencies@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-resolve-dependencies@npm:30.0.0-alpha.2"
   dependencies:
-    jest-regex-util: "npm:^29.6.3"
-    jest-snapshot: "npm:^29.7.0"
-  checksum: b6e9ad8ae5b6049474118ea6441dfddd385b6d1fc471db0136f7c8fbcfe97137a9665e4f837a9f49f15a29a1deb95a14439b7aec812f3f99d08f228464930f0d
+    jest-regex-util: "npm:30.0.0-alpha.2"
+    jest-snapshot: "npm:30.0.0-alpha.2"
+  checksum: 20896130cdf935fb4d798d1df004a81b330545d6ba4874518327fe30adb7ffe806b7c4e890e8bc1da76b8c4ecf4ec8b3457658ab65e5f7c6009eb213d33fe2ad
   languageName: node
   linkType: hard
 
-"jest-resolve@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-resolve@npm:29.7.0"
+"jest-resolve@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-resolve@npm:30.0.0-alpha.2"
   dependencies:
     chalk: "npm:^4.0.0"
     graceful-fs: "npm:^4.2.9"
-    jest-haste-map: "npm:^29.7.0"
+    jest-haste-map: "npm:30.0.0-alpha.2"
     jest-pnp-resolver: "npm:^1.2.2"
-    jest-util: "npm:^29.7.0"
-    jest-validate: "npm:^29.7.0"
+    jest-util: "npm:30.0.0-alpha.2"
+    jest-validate: "npm:30.0.0-alpha.2"
     resolve: "npm:^1.20.0"
     resolve.exports: "npm:^2.0.0"
     slash: "npm:^3.0.0"
-  checksum: 59da5c9c5b50563e959a45e09e2eace783d7f9ac0b5dcc6375dea4c0db938d2ebda97124c8161310082760e8ebbeff9f6b177c15ca2f57fb424f637a5d2adb47
+  checksum: ace80f369779e50105335d56dc9615346d6ce0cf8db65c1fa17c9f006579a2855f60967c1f96c678207e592dceb93884c87e57b19add1588b785ab280f355cb3
   languageName: node
   linkType: hard
 
-"jest-runner@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-runner@npm:29.7.0"
+"jest-runner@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-runner@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/console": "npm:^29.7.0"
-    "@jest/environment": "npm:^29.7.0"
-    "@jest/test-result": "npm:^29.7.0"
-    "@jest/transform": "npm:^29.7.0"
-    "@jest/types": "npm:^29.6.3"
+    "@jest/console": "npm:30.0.0-alpha.2"
+    "@jest/environment": "npm:30.0.0-alpha.2"
+    "@jest/test-result": "npm:30.0.0-alpha.2"
+    "@jest/transform": "npm:30.0.0-alpha.2"
+    "@jest/types": "npm:30.0.0-alpha.2"
     "@types/node": "npm:*"
     chalk: "npm:^4.0.0"
     emittery: "npm:^0.13.1"
     graceful-fs: "npm:^4.2.9"
-    jest-docblock: "npm:^29.7.0"
-    jest-environment-node: "npm:^29.7.0"
-    jest-haste-map: "npm:^29.7.0"
-    jest-leak-detector: "npm:^29.7.0"
-    jest-message-util: "npm:^29.7.0"
-    jest-resolve: "npm:^29.7.0"
-    jest-runtime: "npm:^29.7.0"
-    jest-util: "npm:^29.7.0"
-    jest-watcher: "npm:^29.7.0"
-    jest-worker: "npm:^29.7.0"
+    jest-docblock: "npm:30.0.0-alpha.2"
+    jest-environment-node: "npm:30.0.0-alpha.2"
+    jest-haste-map: "npm:30.0.0-alpha.2"
+    jest-leak-detector: "npm:30.0.0-alpha.2"
+    jest-message-util: "npm:30.0.0-alpha.2"
+    jest-resolve: "npm:30.0.0-alpha.2"
+    jest-runtime: "npm:30.0.0-alpha.2"
+    jest-util: "npm:30.0.0-alpha.2"
+    jest-watcher: "npm:30.0.0-alpha.2"
+    jest-worker: "npm:30.0.0-alpha.2"
     p-limit: "npm:^3.1.0"
     source-map-support: "npm:0.5.13"
-  checksum: 2194b4531068d939f14c8d3274fe5938b77fa73126aedf9c09ec9dec57d13f22c72a3b5af01ac04f5c1cf2e28d0ac0b4a54212a61b05f10b5d6b47f2a1097bb4
+  checksum: 35a99c1bc4b96ab5317a470cb93aa411e7c12c6181b359c3a4b5949959cbdae94380411cb42845f20f0ec42342e624bffa73cb37c2b44d8538a8859d56c16f8b
   languageName: node
   linkType: hard
 
-"jest-runtime@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-runtime@npm:29.7.0"
+"jest-runtime@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-runtime@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/environment": "npm:^29.7.0"
-    "@jest/fake-timers": "npm:^29.7.0"
-    "@jest/globals": "npm:^29.7.0"
-    "@jest/source-map": "npm:^29.6.3"
-    "@jest/test-result": "npm:^29.7.0"
-    "@jest/transform": "npm:^29.7.0"
-    "@jest/types": "npm:^29.6.3"
+    "@jest/environment": "npm:30.0.0-alpha.2"
+    "@jest/fake-timers": "npm:30.0.0-alpha.2"
+    "@jest/globals": "npm:30.0.0-alpha.2"
+    "@jest/source-map": "npm:30.0.0-alpha.2"
+    "@jest/test-result": "npm:30.0.0-alpha.2"
+    "@jest/transform": "npm:30.0.0-alpha.2"
+    "@jest/types": "npm:30.0.0-alpha.2"
     "@types/node": "npm:*"
     chalk: "npm:^4.0.0"
     cjs-module-lexer: "npm:^1.0.0"
     collect-v8-coverage: "npm:^1.0.0"
     glob: "npm:^7.1.3"
     graceful-fs: "npm:^4.2.9"
-    jest-haste-map: "npm:^29.7.0"
-    jest-message-util: "npm:^29.7.0"
-    jest-mock: "npm:^29.7.0"
-    jest-regex-util: "npm:^29.6.3"
-    jest-resolve: "npm:^29.7.0"
-    jest-snapshot: "npm:^29.7.0"
-    jest-util: "npm:^29.7.0"
+    jest-haste-map: "npm:30.0.0-alpha.2"
+    jest-message-util: "npm:30.0.0-alpha.2"
+    jest-mock: "npm:30.0.0-alpha.2"
+    jest-regex-util: "npm:30.0.0-alpha.2"
+    jest-resolve: "npm:30.0.0-alpha.2"
+    jest-snapshot: "npm:30.0.0-alpha.2"
+    jest-util: "npm:30.0.0-alpha.2"
     slash: "npm:^3.0.0"
     strip-bom: "npm:^4.0.0"
-  checksum: 7cd89a1deda0bda7d0941835434e44f9d6b7bd50b5c5d9b0fc9a6c990b2d4d2cab59685ab3cb2850ed4cc37059f6de903af5a50565d7f7f1192a77d3fd6dd2a6
+  checksum: c0747513e6fc3dc162caf7712f0b17d1e5a105c4e14aea3ec0d1a011293fb641dced0fa8a73cd6394009b210be22505f04974e6d4d5f275e59546f1ba1c7e998
   languageName: node
   linkType: hard
 
-"jest-snapshot@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-snapshot@npm:29.7.0"
+"jest-snapshot@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-snapshot@npm:30.0.0-alpha.2"
   dependencies:
     "@babel/core": "npm:^7.11.6"
     "@babel/generator": "npm:^7.7.2"
     "@babel/plugin-syntax-jsx": "npm:^7.7.2"
     "@babel/plugin-syntax-typescript": "npm:^7.7.2"
     "@babel/types": "npm:^7.3.3"
-    "@jest/expect-utils": "npm:^29.7.0"
-    "@jest/transform": "npm:^29.7.0"
-    "@jest/types": "npm:^29.6.3"
+    "@jest/expect-utils": "npm:30.0.0-alpha.2"
+    "@jest/transform": "npm:30.0.0-alpha.2"
+    "@jest/types": "npm:30.0.0-alpha.2"
     babel-preset-current-node-syntax: "npm:^1.0.0"
     chalk: "npm:^4.0.0"
-    expect: "npm:^29.7.0"
+    expect: "npm:30.0.0-alpha.2"
     graceful-fs: "npm:^4.2.9"
-    jest-diff: "npm:^29.7.0"
-    jest-get-type: "npm:^29.6.3"
-    jest-matcher-utils: "npm:^29.7.0"
-    jest-message-util: "npm:^29.7.0"
-    jest-util: "npm:^29.7.0"
+    jest-diff: "npm:30.0.0-alpha.2"
+    jest-get-type: "npm:30.0.0-alpha.2"
+    jest-matcher-utils: "npm:30.0.0-alpha.2"
+    jest-message-util: "npm:30.0.0-alpha.2"
+    jest-util: "npm:30.0.0-alpha.2"
     natural-compare: "npm:^1.4.0"
-    pretty-format: "npm:^29.7.0"
+    pretty-format: "npm:30.0.0-alpha.2"
     semver: "npm:^7.5.3"
-  checksum: 6e9003c94ec58172b4a62864a91c0146513207bedf4e0a06e1e2ac70a4484088a2683e3a0538d8ea913bcfd53dc54a9b98a98cdfa562e7fe1d1339aeae1da570
+    synckit: "npm:^0.8.5"
+  checksum: 64aba71e36c5f93da660aaeca202e268af931f3708e412ebcff86644e0478da729cc1e26976c8091d40523bd16c9f48ac80af4e7b0946d5d11a0c776130029af
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-util@npm:30.0.0-alpha.2"
+  dependencies:
+    "@jest/types": "npm:30.0.0-alpha.2"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.0.0"
+    ci-info: "npm:^4.0.0"
+    graceful-fs: "npm:^4.2.9"
+    picomatch: "npm:^3.0.0"
+  checksum: 4597b506b2efbb5b10be65c11b5aeecd766687aff564bf9060378234b74e50967baa58a45f1fa6e5c549914f2e2869a460638b2fc693a4deb70ac3cb13f6838f
   languageName: node
   linkType: hard
 
@@ -3750,56 +4001,56 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-validate@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-validate@npm:29.7.0"
+"jest-validate@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-validate@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/types": "npm:^29.6.3"
+    "@jest/types": "npm:30.0.0-alpha.2"
     camelcase: "npm:^6.2.0"
     chalk: "npm:^4.0.0"
-    jest-get-type: "npm:^29.6.3"
+    jest-get-type: "npm:30.0.0-alpha.2"
     leven: "npm:^3.1.0"
-    pretty-format: "npm:^29.7.0"
-  checksum: a20b930480c1ed68778c739f4739dce39423131bc070cd2505ddede762a5570a256212e9c2401b7ae9ba4d7b7c0803f03c5b8f1561c62348213aba18d9dbece2
+    pretty-format: "npm:30.0.0-alpha.2"
+  checksum: 0a11c1e234ed61a1b62294a6ca6aa31fcadd7c14665418f6cdbf5fabc1f66f3aa325a856a60c00c51eddf4d25e162443b2bf8a5c31a3f577495c4ea7f3fc1655
   languageName: node
   linkType: hard
 
-"jest-watcher@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-watcher@npm:29.7.0"
+"jest-watcher@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-watcher@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/test-result": "npm:^29.7.0"
-    "@jest/types": "npm:^29.6.3"
+    "@jest/test-result": "npm:30.0.0-alpha.2"
+    "@jest/types": "npm:30.0.0-alpha.2"
     "@types/node": "npm:*"
     ansi-escapes: "npm:^4.2.1"
     chalk: "npm:^4.0.0"
     emittery: "npm:^0.13.1"
-    jest-util: "npm:^29.7.0"
+    jest-util: "npm:30.0.0-alpha.2"
     string-length: "npm:^4.0.1"
-  checksum: ec6c75030562fc8f8c727cb8f3b94e75d831fc718785abfc196e1f2a2ebc9a2e38744a15147170039628a853d77a3b695561ce850375ede3a4ee6037a2574567
+  checksum: fcdde915260142b7134d2b4d03fac4725760c3e2e2f40dd8bbf5391d4093ef3a48e89494a0539d052c4ffcf8d040275f7b975676fc9d3b7f40061f296adaaa9f
   languageName: node
   linkType: hard
 
-"jest-worker@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-worker@npm:29.7.0"
+"jest-worker@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest-worker@npm:30.0.0-alpha.2"
   dependencies:
     "@types/node": "npm:*"
-    jest-util: "npm:^29.7.0"
+    jest-util: "npm:30.0.0-alpha.2"
     merge-stream: "npm:^2.0.0"
     supports-color: "npm:^8.0.0"
-  checksum: 5570a3a005b16f46c131968b8a5b56d291f9bbb85ff4217e31c80bd8a02e7de799e59a54b95ca28d5c302f248b54cbffde2d177c2f0f52ffcee7504c6eabf660
+  checksum: bd499d20de856d5860546aee594803997a93e5659baf9fd8259b2d1546da8f1c4d6c8477bede4e5d62e061c3cceea92b39e1a613998beab6b3c99a9c0a2312bc
   languageName: node
   linkType: hard
 
-"jest@npm:29.7.0":
-  version: 29.7.0
-  resolution: "jest@npm:29.7.0"
+"jest@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "jest@npm:30.0.0-alpha.2"
   dependencies:
-    "@jest/core": "npm:^29.7.0"
-    "@jest/types": "npm:^29.6.3"
+    "@jest/core": "npm:30.0.0-alpha.2"
+    "@jest/types": "npm:30.0.0-alpha.2"
     import-local: "npm:^3.0.2"
-    jest-cli: "npm:^29.7.0"
+    jest-cli: "npm:30.0.0-alpha.2"
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:
@@ -3807,7 +4058,7 @@ __metadata:
       optional: true
   bin:
     jest: bin/jest.js
-  checksum: f40eb8171cf147c617cc6ada49d062fbb03b4da666cb8d39cdbfb739a7d75eea4c3ca150fb072d0d273dce0c753db4d0467d54906ad0293f59c54f9db4a09d8b
+  checksum: 4709028963429ebbceb1fffc0c1b8dcbf1d6318eb1ae72396672f47ffa18d222d5b0c72707804ddc18a3440369d4b865dbde115d45ccd3e4f990ccde1c45659b
   languageName: node
   linkType: hard
 
@@ -3907,13 +4158,6 @@ __metadata:
   dependencies:
     json-buffer: "npm:3.0.1"
   checksum: aa52f3c5e18e16bb6324876bb8b59dd02acf782a4b789c7b2ae21107fab95fab3890ed448d4f8dba80ce05391eeac4bfabb4f02a20221342982f806fa2cf271e
-  languageName: node
-  linkType: hard
-
-"kleur@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "kleur@npm:3.0.3"
-  checksum: cd3a0b8878e7d6d3799e54340efe3591ca787d9f95f109f28129bdd2915e37807bf8918bb295ab86afb8c82196beec5a1adcaf29042ce3f2bd932b038fe3aa4b
   languageName: node
   linkType: hard
 
@@ -4114,6 +4358,13 @@ __metadata:
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
   checksum: b26f5479d7ec6cc2bce275a08f146cf78f5e7b661b18114e2506dd91ec7ec47e7a25bf4360e5438094db0560bcc868079fb3b1fb3892b833c1ecbf63f80c95a4
+  languageName: node
+  linkType: hard
+
+"mimic-fn@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "mimic-fn@npm:4.0.0"
+  checksum: de9cc32be9996fd941e512248338e43407f63f6d497abe8441fa33447d922e927de54d4cc3c1a3c6d652857acd770389d5a3823f311a744132760ce2be15ccbf
   languageName: node
   linkType: hard
 
@@ -4366,6 +4617,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-run-path@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "npm-run-path@npm:5.1.0"
+  dependencies:
+    path-key: "npm:^4.0.0"
+  checksum: ff6d77514489f47fa1c3b1311d09cd4b6d09a874cc1866260f9dea12cbaabda0436ed7f8c2ee44d147bf99a3af29307c6f63b0f83d242b0b6b0ab25dff2629e3
+  languageName: node
+  linkType: hard
+
 "object-inspect@npm:^1.13.1, object-inspect@npm:^1.9.0":
   version: 1.13.1
   resolution: "object-inspect@npm:1.13.1"
@@ -4407,6 +4667,27 @@ __metadata:
   dependencies:
     mimic-fn: "npm:^2.1.0"
   checksum: ffcef6fbb2692c3c40749f31ea2e22677a876daea92959b8a80b521d95cca7a668c884d8b2045d1d8ee7d56796aa405c405462af112a1477594cc63531baeb8f
+  languageName: node
+  linkType: hard
+
+"onetime@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "onetime@npm:6.0.0"
+  dependencies:
+    mimic-fn: "npm:^4.0.0"
+  checksum: 4eef7c6abfef697dd4479345a4100c382d73c149d2d56170a54a07418c50816937ad09500e1ed1e79d235989d073a9bade8557122aee24f0576ecde0f392bb6c
+  languageName: node
+  linkType: hard
+
+"open@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "open@npm:9.1.0"
+  dependencies:
+    default-browser: "npm:^4.0.0"
+    define-lazy-prop: "npm:^3.0.0"
+    is-inside-container: "npm:^1.0.0"
+    is-wsl: "npm:^2.2.0"
+  checksum: 8073ec0dd8994a7a7d9bac208bd17d093993a65ce10f2eb9b62b6d3a91c9366ae903938a237c275493c130171d339f6dcbdd2a2de7e32953452c0867b97825af
   languageName: node
   linkType: hard
 
@@ -4500,7 +4781,7 @@ __metadata:
     char-info: "npm:0.3.2"
     eslint: "npm:8.54.0"
     eslint-plugin-jest: "npm:27.6.0"
-    jest: "npm:29.7.0"
+    jest: "npm:30.0.0-alpha.2"
     lodash: "npm:4.17.21"
     npm-run-all: "npm:4.1.5"
     prettier: "npm:3.0.3"
@@ -4565,6 +4846,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-key@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "path-key@npm:4.0.0"
+  checksum: 794efeef32863a65ac312f3c0b0a99f921f3e827ff63afa5cb09a377e202c262b671f7b3832a4e64731003fa94af0263713962d317b9887bd1e0c48a342efba3
+  languageName: node
+  linkType: hard
+
 "path-parse@npm:^1.0.7":
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
@@ -4609,6 +4897,13 @@ __metadata:
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "picomatch@npm:3.0.1"
+  checksum: 70ec738569f1864658378b7abdab8939d15dae0718c1df994eae3346fd33daf6a3c1ff4e0c1a0cd1e2c0319130985b63a2cff34d192f2f2acbb78aca76111736
   languageName: node
   linkType: hard
 
@@ -4660,6 +4955,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:30.0.0-alpha.2":
+  version: 30.0.0-alpha.2
+  resolution: "pretty-format@npm:30.0.0-alpha.2"
+  dependencies:
+    "@jest/schemas": "npm:30.0.0-alpha.2"
+    ansi-styles: "npm:^5.0.0"
+    react-is: "npm:^18.0.0"
+  checksum: 4b0644d4937a41dc1bb079d2b1c0137f7edc4621490e5cd791b73eabda4f659be12e62aff6d83d56ea613341cc6fb5933c5d11258902779152d6e224a792586a
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:^29.0.0, pretty-format@npm:^29.7.0":
   version: 29.7.0
   resolution: "pretty-format@npm:29.7.0"
@@ -4685,16 +4991,6 @@ __metadata:
     err-code: "npm:^2.0.2"
     retry: "npm:^0.12.0"
   checksum: 9c7045a1a2928094b5b9b15336dcd2a7b1c052f674550df63cc3f36cd44028e5080448175b6f6ca32b642de81150f5e7b1a98b728f15cb069f2dd60ac2616b96
-  languageName: node
-  linkType: hard
-
-"prompts@npm:^2.0.1":
-  version: 2.4.2
-  resolution: "prompts@npm:2.4.2"
-  dependencies:
-    kleur: "npm:^3.0.3"
-    sisteransi: "npm:^1.0.5"
-  checksum: 16f1ac2977b19fe2cf53f8411cc98db7a3c8b115c479b2ca5c82b5527cd937aa405fa04f9a5960abeb9daef53191b53b4d13e35c1f5d50e8718c76917c5f1ea4
   languageName: node
   linkType: hard
 
@@ -4842,6 +5138,15 @@ __metadata:
   bin:
     rimraf: bin.js
   checksum: 9cb7757acb489bd83757ba1a274ab545eafd75598a9d817e0c3f8b164238dd90eba50d6b848bd4dcc5f3040912e882dc7ba71653e35af660d77b25c381d402e8
+  languageName: node
+  linkType: hard
+
+"run-applescript@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "run-applescript@npm:5.0.0"
+  dependencies:
+    execa: "npm:^5.0.0"
+  checksum: f9977db5770929f3f0db434b8e6aa266498c70dec913c84320c0a06add510cf44e3a048c44da088abee312006f9cbf572fd065cdc8f15d7682afda8755f4114c
   languageName: node
   linkType: hard
 
@@ -5041,13 +5346,6 @@ __metadata:
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
-  languageName: node
-  linkType: hard
-
-"sisteransi@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "sisteransi@npm:1.0.5"
-  checksum: 230ac975cca485b7f6fe2b96a711aa62a6a26ead3e6fb8ba17c5a00d61b8bed0d7adc21f5626b70d7c33c62ff4e63933017a6462942c719d1980bb0b1207ad46
   languageName: node
   linkType: hard
 
@@ -5294,6 +5592,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-final-newline@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-final-newline@npm:3.0.0"
+  checksum: a771a17901427bac6293fd416db7577e2bc1c34a19d38351e9d5478c3c415f523f391003b42ed475f27e33a78233035df183525395f731d3bfb8cdcbd4da08ce
+  languageName: node
+  linkType: hard
+
 "strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
@@ -5335,6 +5640,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"synckit@npm:^0.8.5":
+  version: 0.8.5
+  resolution: "synckit@npm:0.8.5"
+  dependencies:
+    "@pkgr/utils": "npm:^2.3.1"
+    tslib: "npm:^2.5.0"
+  checksum: 9827f828cabc404b3a147c38f824c8d5b846eb6f65189d965aa0b71ea8ecda5048f8f50b4bdfd8813148844175233cff56c6bc8d87a7118cf10707df870519f4
+  languageName: node
+  linkType: hard
+
 "tar@npm:^6.1.11, tar@npm:^6.1.2":
   version: 6.2.0
   resolution: "tar@npm:6.2.0"
@@ -5364,6 +5679,13 @@ __metadata:
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
   checksum: 02805740c12851ea5982686810702e2f14369a5f4c5c40a836821e3eefc65ffeec3131ba324692a37608294b0fd8c1e55a2dd571ffed4909822787668ddbee5c
+  languageName: node
+  linkType: hard
+
+"titleize@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "titleize@npm:3.0.0"
+  checksum: 5ae6084ba299b5782f95e3fe85ea9f0fa4d74b8ae722b6b3208157e975589fbb27733aeba4e5080fa9314a856044ef52caa61b87caea4b1baade951a55c06336
   languageName: node
   linkType: hard
 
@@ -5441,6 +5763,13 @@ __metadata:
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: 69ae09c49eea644bc5ebe1bca4fa4cc2c82b7b3e02f43b84bd891504edf66dbc6b2ec0eef31a957042de2269139e4acff911e6d186a258fb14069cd7f6febce2
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.5.0, tslib@npm:^2.6.0":
+  version: 2.6.2
+  resolution: "tslib@npm:2.6.2"
+  checksum: e03a8a4271152c8b26604ed45535954c0a45296e32445b4b87f8a5abdb2421f40b59b4ca437c4346af0f28179780d604094eb64546bee2019d903d01c6c19bdb
   languageName: node
   linkType: hard
 
@@ -5614,6 +5943,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"untildify@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "untildify@npm:4.0.0"
+  checksum: d758e624c707d49f76f7511d75d09a8eda7f2020d231ec52b67ff4896bcf7013be3f9522d8375f57e586e9a2e827f5641c7e06ee46ab9c435fc2b2b2e9de517a
+  languageName: node
+  linkType: hard
+
 "update-browserslist-db@npm:^1.0.13":
   version: 1.0.13
   resolution: "update-browserslist-db@npm:1.0.13"
@@ -5776,13 +6112,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"write-file-atomic@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "write-file-atomic@npm:4.0.2"
+"write-file-atomic@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "write-file-atomic@npm:5.0.1"
   dependencies:
     imurmurhash: "npm:^0.1.4"
-    signal-exit: "npm:^3.0.7"
-  checksum: a2c282c95ef5d8e1c27b335ae897b5eca00e85590d92a3fd69a437919b7b93ff36a69ea04145da55829d2164e724bc62202cdb5f4b208b425aba0807889375c7
+    signal-exit: "npm:^4.0.1"
+  checksum: e8c850a8e3e74eeadadb8ad23c9d9d63e4e792bd10f4836ed74189ef6e996763959f1249c5650e232f3c77c11169d239cbfc8342fc70f3fe401407d23810505d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1792,15 +1792,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bs-logger@npm:0.x":
-  version: 0.2.6
-  resolution: "bs-logger@npm:0.2.6"
-  dependencies:
-    fast-json-stable-stringify: "npm:2.x"
-  checksum: 80e89aaaed4b68e3374ce936f2eb097456a0dddbf11f75238dbd53140b1e39259f0d248a5089ed456f1158984f22191c3658d54a713982f676709fbe1a6fa5a0
-  languageName: node
-  linkType: hard
-
 "bser@npm:2.1.1":
   version: 2.1.1
   resolution: "bser@npm:2.1.1"
@@ -2551,7 +2542,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
+"fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
   checksum: 7f081eb0b8a64e0057b3bb03f974b3ef00135fbf36c1c710895cd9300f13c94ba809bb3a81cf4e1b03f6e5285610a61abbd7602d0652de423144dfee5a389c9b
@@ -3745,7 +3736,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^29.0.0, jest-util@npm:^29.7.0":
+"jest-util@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-util@npm:29.7.0"
   dependencies:
@@ -3980,13 +3971,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.memoize@npm:4.x":
-  version: 4.1.2
-  resolution: "lodash.memoize@npm:4.1.2"
-  checksum: c8713e51eccc650422716a14cece1809cfe34bc5ab5e242b7f8b4e2241c2483697b971a604252807689b9dd69bfe3a98852e19a5b89d506b000b4187a1285df8
-  languageName: node
-  linkType: hard
-
 "lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
@@ -4051,7 +4035,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-error@npm:1.x, make-error@npm:^1.1.1":
+"make-error@npm:^1.1.1":
   version: 1.3.6
   resolution: "make-error@npm:1.3.6"
   checksum: 171e458d86854c6b3fc46610cfacf0b45149ba043782558c6875d9f42f222124384ad0b468c92e996d815a8a2003817a710c0a160e49c1c394626f76fa45396f
@@ -4524,7 +4508,6 @@ __metadata:
     shx: "npm:0.3.4"
     source-map: "npm:0.7.4"
     source-map-support: "npm:0.5.21"
-    ts-jest: "npm:29.1.1"
     ts-node: "npm:10.9.1"
     typedoc: "npm:0.25.3"
     typedoc-plugin-internal-external: "npm:2.2.0"
@@ -5416,39 +5399,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:29.1.1":
-  version: 29.1.1
-  resolution: "ts-jest@npm:29.1.1"
-  dependencies:
-    bs-logger: "npm:0.x"
-    fast-json-stable-stringify: "npm:2.x"
-    jest-util: "npm:^29.0.0"
-    json5: "npm:^2.2.3"
-    lodash.memoize: "npm:4.x"
-    make-error: "npm:1.x"
-    semver: "npm:^7.5.3"
-    yargs-parser: "npm:^21.0.1"
-  peerDependencies:
-    "@babel/core": ">=7.0.0-beta.0 <8"
-    "@jest/types": ^29.0.0
-    babel-jest: ^29.0.0
-    jest: ^29.0.0
-    typescript: ">=4.3 <6"
-  peerDependenciesMeta:
-    "@babel/core":
-      optional: true
-    "@jest/types":
-      optional: true
-    babel-jest:
-      optional: true
-    esbuild:
-      optional: true
-  bin:
-    ts-jest: cli.js
-  checksum: 6c45e0aeeff9cc54a64f931c43e1b99f4a1f0ddf44786cc128e7e55603ab7473c8c8f62fd83bd7e51bfe83e3c0c683132152efaeb844516bf7c923f4e92d157d
-  languageName: node
-  linkType: hard
-
 "ts-node@npm:10.9.1":
   version: 10.9.1
   resolution: "ts-node@npm:10.9.1"
@@ -5857,7 +5807,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^21.0.1, yargs-parser@npm:^21.1.1":
+"yargs-parser@npm:^21.1.1":
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
   checksum: f84b5e48169479d2f402239c59f084cfd1c3acc197a05c59b98bab067452e6b3ea46d4dd8ba2985ba7b3d32a343d77df0debd6b343e5dae3da2aab2cdf5886b2


### PR DESCRIPTION
In this PR I have included various small improvements. The highlights:

- some parsers now return a constant type instead of `string`. This allows returning constant types to combinators and as output values. This can be very useful:

```ts
anyStringOf("true", "false") // now returns Parjser<"true" | "false">, so there's no need to perform runtime validation to satisfy the type checker anymore
```
This should be a backwards compatible change.

- some internal testing related improvements
- some small scale refactoring
