### PR TITLE
feat: example .ini file format parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ console.log(surrounded.parse("(1,  2 , 3 )"));
 
 Here are some more cool examples:
 
+1. [.ini parser](https://github.com/GregRos/parjs/blob/master/src/examples/ini.ts)
 1. [JSON parser](https://github.com/GregRos/parjs/blob/master/src/examples/json.ts)
-2. [Math expression parser](https://github.com/GregRos/parjs/blob/master/src/examples/math.ts)
+1. [Math expression parser](https://github.com/GregRos/parjs/blob/master/src/examples/math.ts)
 
 ## How does it work?
 

--- a/src/examples/ini.ts
+++ b/src/examples/ini.ts
@@ -1,0 +1,121 @@
+import { Parjser, anyCharOf, eof, newline, result, string } from "../lib";
+import { many, map, or, qthen, stringify, then, thenq } from "../lib/combinators";
+import { between, many1, maybe } from "../lib/internal/combinators";
+
+// This is a parser for .ini files. It's a simple format that looks like this:
+//
+//     ; Global section
+//     abc=def
+//     ghi=jkl
+//
+//     [SectionName]
+//     abc=def
+//     ghi=jkl ; comment
+//
+//     [AnotherSection]
+//     mno=pqr
+//
+// The parser is based on the following grammar:
+// - Properties: These are key-value pairs, parsed by definitionLine. The keys
+//   are case-insensitive.
+// - Comments: These start with a ; or # and continue to the end of the line.
+//   They can appear anywhere in the file, including on the same line as a
+//   property.
+// - Sections: These are groups of properties under a header, like
+//   [SectionName]. The sectionHeader parser recognizes these headers.
+// - Empty lines: These are recognized by the emptyLine parser. They can appear
+//   anywhere in the file and are ignored by the parser.
+// - Global Section: This is a special section that contains properties defined
+//   before any named section.
+
+export class Property {
+    constructor(
+        public readonly name: string,
+        public readonly value: string
+    ) {}
+}
+
+export class EmptyLine {}
+
+export class NamedSection {
+    constructor(
+        public readonly name: string,
+        public readonly properties: Property | EmptyLine[]
+    ) {}
+}
+
+export class GlobalSection {
+    constructor(public readonly properties: Property | EmptyLine[]) {}
+}
+
+export class IniFile {
+    constructor(
+        public readonly global: GlobalSection,
+        public readonly sections: NamedSection[]
+    ) {}
+}
+
+const maybeSpacesOrTabs = string(" ").pipe(or(string("\t")), many());
+function token<T>(parser: Parjser<T>): Parjser<T> {
+    return parser.pipe(between(maybeSpacesOrTabs));
+}
+
+const identifierCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
+const valueCharacters = identifierCharacters + " \t";
+
+export const comment = token(anyCharOf(";#"))
+    .pipe(qthen(anyCharOf(valueCharacters).pipe(many(), stringify())))
+    .expects("comment");
+
+export const identifier = token(anyCharOf(identifierCharacters).pipe(many1(), stringify())).expects(
+    "identifier"
+);
+export const value = anyCharOf(valueCharacters).pipe(many1(), stringify()).expects("value");
+
+// parses a definition like `abc=def`.
+// Note that definitions are case insensitive in .ini files
+export const definitionLine = token(identifier)
+    .pipe(
+        thenq(token(string("="))),
+        then(value, comment.pipe(maybe())),
+        thenq(newline().pipe(or(eof()))),
+        map(([name, val]) => new Property(name.toLowerCase(), val))
+    )
+    .expects("definition");
+
+const emptyLine = comment
+    .pipe(maybe(), qthen(maybeSpacesOrTabs))
+    .pipe(qthen(newline()), qthen(result(new EmptyLine())))
+    .expects("empty line");
+
+// parses many definitions
+export const definitionList = emptyLine
+    .pipe(or(definitionLine), many())
+    .expects("definitionSection");
+
+export const sectionHeader = token(
+    anyCharOf(valueCharacters).pipe(many1(), stringify(), between("[", "]"))
+)
+    .pipe(thenq(comment.pipe(maybe())))
+    .expects("section header");
+
+export const section = sectionHeader
+    .pipe(
+        thenq(newline()),
+        then(definitionList),
+        map(([name, properties]) => new NamedSection(name, properties))
+    )
+    .expects("section");
+
+// parses the variables at the top of the file. These are called global because they are not
+// associated with any section.
+export const globalSection = definitionList
+    .pipe(map(properties => new GlobalSection(properties)))
+    .expects("global section");
+
+export const iniFile = globalSection
+    .pipe(
+        then(section.pipe(many())),
+        map(([global, sections]) => new IniFile(global, sections))
+    )
+    .expects("ini file");

--- a/src/lib/internal/combinators/reason.ts
+++ b/src/lib/internal/combinators/reason.ts
@@ -1,11 +1,12 @@
-import { defineCombinator } from "./combinator";
-import { ParjserBase } from "../parser";
-import { ParsingState } from "../state";
-import { FailureInfo } from "../result";
 import { ParjsCombinator } from "../parjser";
+import { ParjserBase } from "../parser";
+import { FailureInfo } from "../result";
+import { ParsingState } from "../state";
+import { defineCombinator } from "./combinator";
 
 /**
  * Applies the source parser, modifying the failure reason to the given message if it fails Softly.
+ * Useful for providing the user with a more meaningful error message than was is provided by default.
  * @param message The new message.
  */
 export function reason<T>(message: string): ParjsCombinator<T, T>;

--- a/src/lib/internal/parser.ts
+++ b/src/lib/internal/parser.ts
@@ -93,8 +93,9 @@ export abstract class ParjserBase<TValue> implements Parjser<TValue> {
     }
 
     debug(fn: ParjserDebugFunction = defaultDebugFunction): Parjser<TValue> {
-        this.debugFunction = fn;
-        return this;
+        const copy = clone(this);
+        copy.debugFunction = fn;
+        return copy;
     }
 
     /**

--- a/src/test/examples/ini.spec.ts
+++ b/src/test/examples/ini.spec.ts
@@ -1,0 +1,244 @@
+import {
+    EmptyLine,
+    GlobalSection,
+    IniFile,
+    NamedSection,
+    Property,
+    comment,
+    definitionLine,
+    definitionList,
+    globalSection,
+    identifier,
+    iniFile,
+    section,
+    sectionHeader,
+    value
+} from "../../examples/ini";
+
+describe("comments", () => {
+    it("can parse a ; comment", () => {
+        expect(comment.parse("; this is a comment")).toBeSuccessful("this is a comment");
+    });
+
+    it("can parse a # comment", () => {
+        expect(comment.parse("# this is a comment")).toBeSuccessful("this is a comment");
+    });
+
+    it("parse a comment at the end of the file", () => {
+        expect(comment.parse("; this is a comment")).toBeSuccessful("this is a comment");
+    });
+});
+
+describe("identifiers", () => {
+    it("can parse a simple identifier", () => {
+        expect(identifier.parse("abc")).toBeSuccessful("abc");
+    });
+
+    it("cannot be empty", () => {
+        expect(identifier.parse("")).toBeFailure();
+    });
+});
+
+describe("values", () => {
+    it("can parse a simple value", () => {
+        expect(value.parse("abc")).toBeSuccessful("abc");
+    });
+
+    it("cannot be empty", () => {
+        expect(value.parse("")).toBeFailure();
+    });
+
+    it("can contain spaces", () => {
+        expect(value.parse("abc def")).toBeSuccessful("abc def");
+    });
+
+    it("can contain tabs", () => {
+        expect(value.parse("abc\tdef")).toBeSuccessful("abc\tdef");
+    });
+});
+
+describe("definitionLine", () => {
+    it("can parse a simple definition", () => {
+        expect(definitionLine.parse("abc=def")).toBeSuccessful(new Property("abc", "def"));
+    });
+
+    it("can parse a definition with spaces", () => {
+        expect(definitionLine.parse("abc = def ")).toBeSuccessful(new Property("abc", "def "));
+    });
+
+    it("can parse a definition with tabs", () => {
+        expect(definitionLine.parse("abc\t=\tdef ")).toBeSuccessful(new Property("abc", "def "));
+    });
+
+    it("can parse a definition with a comment", () => {
+        expect(definitionLine.parse("abc=def ; comment")).toBeSuccessful(
+            new Property("abc", "def ")
+        );
+    });
+
+    it("converts the name to lowercase", () => {
+        expect(definitionLine.parse("ABC=def")).toBeSuccessful(new Property("abc", "def"));
+    });
+});
+
+describe("definitionList", () => {
+    it("can parse many definitions", () => {
+        const input = [
+            //
+            "abc=def",
+            "ghi=jkl"
+        ].join("\n");
+        expect(definitionList.parse(input)).toBeSuccessful([
+            new Property("abc", "def"),
+            new Property("ghi", "jkl")
+        ]);
+    });
+
+    it("can have empty lines between definitions", () => {
+        const input = [
+            //
+            "abc=def",
+            "",
+            "ghi=jkl"
+        ].join("\n");
+        expect(definitionList.parse(input)).toBeSuccessful([
+            new Property("abc", "def"),
+            new EmptyLine(),
+            new Property("ghi", "jkl")
+        ]);
+    });
+
+    it("can have empty lines with comments between definitions", () => {
+        const input = [
+            //
+            "abc=def",
+            "; comment",
+            "ghi=jkl"
+        ].join("\n");
+        expect(definitionList.parse(input)).toBeSuccessful([
+            new Property("abc", "def"),
+            new EmptyLine(),
+            new Property("ghi", "jkl")
+        ]);
+    });
+});
+
+describe("section headers", () => {
+    it("can parse a simple section header", () => {
+        expect(sectionHeader.parse("[abc]")).toBeSuccessful("abc");
+    });
+
+    it("cannot be empty", () => {
+        expect(sectionHeader.parse("[]")).toBeFailure();
+    });
+
+    it("can contain spaces", () => {
+        expect(sectionHeader.parse("[abc def]")).toBeSuccessful("abc def");
+    });
+
+    it("can contain tabs", () => {
+        expect(sectionHeader.parse("[abc\tdef]")).toBeSuccessful("abc\tdef");
+    });
+
+    it("can have a comment at the end", () => {
+        expect(sectionHeader.parse("[abc] ; comment")).toBeSuccessful("abc");
+    });
+});
+
+describe("sections", () => {
+    it("can parse a simple section", () => {
+        const input = [
+            //
+            "[abc]",
+            "def=ghi",
+            "jkl=mno"
+        ].join("\n");
+        expect(section.parse(input)).toBeSuccessful(
+            new NamedSection("abc", [new Property("def", "ghi"), new Property("jkl", "mno")])
+        );
+    });
+});
+
+describe("global section", () => {
+    it("can parse a simple global section", () => {
+        const input = [
+            //
+            "def=ghi",
+            "",
+            "; comment",
+            "jkl=mno"
+        ].join("\n");
+        expect(globalSection.parse(input)).toBeSuccessful(
+            new GlobalSection([
+                new Property("def", "ghi"),
+                new EmptyLine(),
+                new EmptyLine(),
+                new Property("jkl", "mno")
+            ])
+        );
+    });
+});
+
+describe("ini file", () => {
+    it("can parse a simple ini file", () => {
+        const input = [
+            "; This is the global section",
+            "globalKey1=globalValue1",
+            "globalKey2=globalValue2",
+            "",
+            "[Section1]",
+            "Key1=Value1",
+            "; line comment",
+            "# another line comment",
+            "Key2=Value2",
+            "[Section2]",
+            "KeyA=ValueA",
+            "",
+            "KeyB=ValueB"
+        ].join("\n");
+        expect(iniFile.parse(input)).toBeSuccessful(
+            new IniFile(
+                new GlobalSection([
+                    new EmptyLine(),
+                    new Property("globalkey1", "globalValue1"),
+                    new Property("globalkey2", "globalValue2"),
+                    new EmptyLine()
+                ]),
+                [
+                    new NamedSection("Section1", [
+                        new Property("key1", "Value1"),
+                        new EmptyLine(),
+                        new EmptyLine(),
+                        new Property("key2", "Value2")
+                    ]),
+                    new NamedSection("Section2", [
+                        new Property("keya", "ValueA"),
+                        new EmptyLine(),
+                        new Property("keyb", "ValueB")
+                    ])
+                ]
+            )
+        );
+    });
+
+    it("isn't required to have a global section", () => {
+        const input = ["[Section1]", "Key1=Value1"].join("\n");
+        expect(iniFile.parse(input)).toBeSuccessful(
+            new IniFile(new GlobalSection([]), [
+                new NamedSection("Section1", [new Property("key1", "Value1")])
+            ])
+        );
+    });
+
+    it("can have an empty section", () => {
+        const input = ["[Section1]", ""].join("\n");
+        expect(iniFile.parse(input)).toBeSuccessful(
+            new IniFile(new GlobalSection([]), [new NamedSection("Section1", [])])
+        );
+    });
+
+    it("can have no contents", () => {
+        const input = "";
+        expect(iniFile.parse(input)).toBeSuccessful(new IniFile(new GlobalSection([]), []));
+    });
+});


### PR DESCRIPTION
feat: example .ini file format parser

This is a parser for .ini files. It's a simple format that looks like this:

    ; Global section
    abc=def
    ghi=jkl
    [SectionName]
    abc=def
    ghi=jkl ; comment
    [AnotherSection]
    mno=pqr

The parser is based on the following grammar:

- Properties: These are key-value pairs, parsed by definitionLine. The keys
  are case-insensitive.
- Comments: These start with a ; or # and continue to the end of the line.
  They can appear anywhere in the file, including on the same line as a
  property.
- Sections: These are groups of properties under a header, like
  [SectionName]. The sectionHeader parser recognizes these headers.
- Empty lines: These are recognized by the emptyLine parser. They can appear
  anywhere in the file and are ignored by the parser.
- Global Section: This is a special section that contains properties defined
  before any named section.