### PR TITLE
Feature/remove namespaces

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
-const path = require("path");
+// @ts-check
 
-module.exports = {
+/** @type {import("@typescript-eslint/utils/dist/ts-eslint/Linter").Linter.Config} c */
+const config = {
     root: true,
     extends: [
         "@gregros/eslint-config",
@@ -10,10 +11,8 @@ module.exports = {
     parser: "@typescript-eslint/parser",
     plugins: ["@typescript-eslint", "jest"],
     rules: {
-        // 'any' is used in many places to simplify the type system
-        "@typescript-eslint/no-explicit-any": "warn",
-
-        "@typescript-eslint/no-namespace": "off",
+        "@typescript-eslint/no-explicit-any": "error",
+        "@typescript-eslint/no-namespace": "error",
 
         // eslint's rule needs to be switched off in favour of the typescript one
         "@typescript-eslint/no-shadow": "error",
@@ -24,3 +23,4 @@ module.exports = {
         project: "**/tsconfig.json"
     }
 };
+module.exports = config;

--- a/src/lib/internal/combinators/many-sep-by.ts
+++ b/src/lib/internal/combinators/many-sep-by.ts
@@ -76,7 +76,7 @@ export function manySepBy<E, Sep>(implDelimeter: ImplicitParjser<Sep>, max = Inf
                         return;
                     }
                     if (max >= Infinity && ps.position === position) {
-                        Issues.guardAgainstInfiniteLoop("many");
+                        Issues.guardAgainstInfiniteLoop("manySepBy");
                     }
                     results.push(ps.value as E);
                     position = ps.position;

--- a/src/lib/internal/combinators/many-sep-by.ts
+++ b/src/lib/internal/combinators/many-sep-by.ts
@@ -3,12 +3,12 @@
  */
 /** */
 
+import { ImplicitParjser, ParjsCombinator } from "../../index";
 import { Issues } from "../issues";
-import { ResultKind } from "../result";
-import { ParsingState } from "../state";
-import { ImplicitParjser, ParjsCombinator, Parjser } from "../../index";
-import { ScalarConverter } from "../scalar-converter";
 import { ParjserBase } from "../parser";
+import { ResultKind } from "../result";
+import { ScalarConverter } from "../scalar-converter";
+import { ParsingState } from "../state";
 import { defineCombinator } from "./combinator";
 
 export type ArrayWithSeparators<Normal, Separator> = Normal[] & {
@@ -40,7 +40,7 @@ export function manySepBy<E, Sep>(
 ): ParjsCombinator<E, ArrayWithSeparators<E, Sep>>;
 
 export function manySepBy<E, Sep>(implDelimeter: ImplicitParjser<Sep>, max = Infinity) {
-    const delimeter = ScalarConverter.convert(implDelimeter) as ParjserBase<Sep> & Parjser<Sep>;
+    const delimeter = ScalarConverter.convert(implDelimeter) as ParjserBase<Sep>;
     return defineCombinator<E, E>(source => {
         return new (class extends ParjserBase<E> {
             type = "manySepBy";

--- a/src/lib/internal/combinators/recover.ts
+++ b/src/lib/internal/combinators/recover.ts
@@ -4,7 +4,7 @@
 /** */
 
 import { ParjsCombinator } from "../../";
-import { FailureInfo, ResultKind, SuccessInfo } from "../result";
+import { FailureInfo, ResultKindFail, SuccessInfo } from "../result";
 import { ParsingState, UserState } from "../state";
 
 import { ParjserBase } from "../parser";
@@ -25,7 +25,7 @@ export interface ParserFailureState {
     /**
      * The severity of the failure.
      */
-    readonly kind: ResultKind.Fail;
+    readonly kind: ResultKindFail;
 }
 
 /**
@@ -50,7 +50,7 @@ export function recover<T>(recoverFunction: RecoveryFunction<T>): ParjsCombinato
                 if (ps.isOk || ps.isFatal) return;
                 const result = recoverFunction({
                     userState: ps.userState,
-                    kind: ps.kind as ResultKind.Fail,
+                    kind: ps.kind as ResultKindFail,
                     reason: ps.reason! // the error is guaranteed to be non-null
                 } satisfies ParserFailureState);
                 if (!result) return;

--- a/src/lib/internal/functions/helpers.ts
+++ b/src/lib/internal/functions/helpers.ts
@@ -5,36 +5,37 @@
 import repeat from "lodash/repeat";
 
 /**
+ * Recursively applies join to an array of arrays.
+ * @param arr
+ */
+type StringOrArray = string | StringOrArray[];
+
+/**
  * Some simple helpers for working with strings.
  */
-export namespace StringHelpers {
-    /**
-     * Recursively applies join to an array of arrays.
-     * @param arr
-     */
-    type StringOrArray = string | StringOrArray[];
-    export function recJoin(arr: StringOrArray): string {
+export const StringHelpers = {
+    recJoin(arr: StringOrArray): string {
         if (arr instanceof Array) {
-            return arr.map(x => recJoin(x)).join("");
+            return arr.map(x => this.recJoin(x)).join("");
         } else {
             return String(arr);
         }
     }
-}
+};
 
 /**
  * Helpers for working with numbers.
  */
-export namespace NumHelpers {
+export const NumHelpers = {
     /**
      * Pads an integer with characters.
      * @param n
      * @param digits
      * @param char
      */
-    export function padInt(n: number, digits: number, char: string) {
+    padInt(n: number, digits: number, char: string) {
         const str = n.toString();
         if (str.length >= digits) return str;
         return repeat(char, digits - str.length) + str;
     }
-}
+};

--- a/src/lib/internal/issues.ts
+++ b/src/lib/internal/issues.ts
@@ -7,24 +7,24 @@ import { ParserDefinitionError } from "../errors";
 /**
  * Some canned error throwers.
  */
-export namespace Issues {
+export const Issues = {
     /**
      * Throws an error saying that the parser is about to enter an infinite
      * loop.
      * @param name
      */
-    export function guardAgainstInfiniteLoop(name: string): never {
+    guardAgainstInfiniteLoop(name: string): never {
         throw new ParserDefinitionError(
             name,
             `The combinator '${name}' expected one of its arguments to change the parser state.`
         );
-    }
+    },
 
-    export function delayedParserNotInit(name: string): never {
+    delayedParserNotInit(name: string): never {
         throw new ParserDefinitionError(name, `Delayed parser not initalized.`);
-    }
+    },
 
-    export function delayedParserAlreadyInit(): never {
+    delayedParserAlreadyInit(): never {
         throw new ParserDefinitionError("", `Delayed parser has already been initialized`);
     }
-}
+};

--- a/src/lib/internal/result.ts
+++ b/src/lib/internal/result.ts
@@ -33,7 +33,7 @@ export class ParjsSuccess<T> implements SuccessInfo<T> {
  * Info about a success.
  */
 export interface SuccessInfo<T> {
-    kind: ResultKind.Ok;
+    kind: ResultKindOk;
     value: T;
 }
 
@@ -41,7 +41,7 @@ export interface SuccessInfo<T> {
  * Info about a potential failure.
  */
 export interface FailureInfo {
-    kind: ResultKind.Fail;
+    kind: ResultKindFail;
     reason: string;
 }
 
@@ -113,47 +113,48 @@ export type ParjsResult<T> = ParjsSuccess<T> | ParjsFailure;
 /**
  * Namespace that contains the different reply kinds/error levels.
  */
-export namespace ResultKind {
-    /**
-     * The OK reply type.
-     */
-    export type Ok = "OK";
-    /**
-     * The soft failure type.
-     */
-    export type SoftFail = "Soft";
-    /**
-     * The hard failure type.
-     */
-    export type HardFail = "Hard";
-    /**
-     * The fatal failure type.
-     */
-    export type FatalFail = "Fatal";
-
+export const ResultKind = {
     /**
      * An OK reply.
      */
-    export const Ok: Ok = "OK";
+    Ok: "OK" as const,
     /**
      * A soft failure reply.
      */
-    export const SoftFail: SoftFail = "Soft";
+    SoftFail: "Soft" as const,
     /**
      * A hard failure reply.
      */
-    export const HardFail: HardFail = "Hard";
+    HardFail: "Hard" as const,
     /**
      * A fatal failure reply.
      */
-    export const FatalFail: FatalFail = "Fatal";
+    FatalFail: "Fatal" as const
+};
 
-    /**
-     * Specifies any kind of failure.
-     */
-    export type Fail = HardFail | FatalFail | SoftFail;
-}
+/**
+ * The OK reply type.
+ */
+export type ResultKindOk = typeof ResultKind.Ok;
+/**
+ * The soft failure type.
+ */
+export type ResultKindSoftFail = typeof ResultKind.SoftFail;
+/**
+ * The hard failure type.
+ */
+export type ResultKindHardFail = typeof ResultKind.HardFail;
+/**
+ * The fatal failure type.
+ */
+export type ResultKindFatalFail = typeof ResultKind.FatalFail;
+
+/**
+ * Specifies any kind of failure.
+ */
+export type ResultKindFail = ResultKindHardFail | ResultKindFatalFail | ResultKindSoftFail;
+
 /**
  * Specifies a reply kind, indicating success or failure, and the severity of the failure.
  */
-export type ResultKind = ResultKind.Ok | ResultKind.Fail;
+export type ResultKind = ResultKindOk | ResultKindFail;

--- a/src/lib/internal/scalar-converter.ts
+++ b/src/lib/internal/scalar-converter.ts
@@ -45,12 +45,12 @@ export type ImplicitParjser<T> = Parjser<T> | ConvertibleScalar<T>;
 /**
  * A helper for working with implicit parsers.
  */
-export namespace ScalarConverter {
+export const ScalarConverter = {
     /**
      * Normalizes scalars and Parjsers into Parjsers.
      * @param scalarOrParjser The literal or parjser.
      */
-    export function convert<V>(scalarOrParjser: ImplicitParjser<V>): Parjser<V> {
+    convert<V>(scalarOrParjser: ImplicitParjser<V>): Parjser<V> {
         if (typeof scalarOrParjser === "string") {
             return string(scalarOrParjser) as Parjser<V>;
         } else if (scalarOrParjser instanceof RegExp) {
@@ -59,4 +59,4 @@ export namespace ScalarConverter {
             return scalarOrParjser as Parjser<V>;
         }
     }
-}
+};

--- a/src/test/helpers/jest-setup.ts
+++ b/src/test/helpers/jest-setup.ts
@@ -87,6 +87,7 @@ expect.extend({
 });
 
 declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace jest {
         interface Matchers<R> {
             toBeSuccessful<T>(value?: T): R;


### PR DESCRIPTION
# refactor!: remove all ts namespaces

This is technically a breaking change because the types are no longer accessed through the namespace qualifiers.
It should be very easy to resolve, though.