### PR TITLE
fix(types): Infer parsed string subtype

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parjs",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "repository": "https://github.com/GregRos/parjs",
   "homepage": "https://github.com/GregRos/parjs",
   "exports": {

--- a/src/lib/internal/util-types.ts
+++ b/src/lib/internal/util-types.ts
@@ -22,7 +22,7 @@ export type union<Args extends unknown[]> = Args extends [
 export type getParsedType<T extends ImplicitParjser<unknown>> = T extends RegExp
     ? string[]
     : T extends string
-    ? string
+    ? T
     : T extends Parjser<infer U>
     ? U
     : never;


### PR DESCRIPTION
Fixed `getParsedType` as @sp3ctum suggested.