### PR TITLE
fix: stringLen failing on repeated parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parjs",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "repository": "https://github.com/GregRos/parjs",
   "homepage": "https://github.com/GregRos/parjs",
   "exports": {

--- a/src/lib/internal/parsers/string-len.ts
+++ b/src/lib/internal/parsers/string-len.ts
@@ -19,7 +19,7 @@ class StringLen extends ParjserBase<string> {
             return;
         }
         ps.position += length;
-        ps.value = input.substring(position, length);
+        ps.value = input.substring(position, position + length);
         ps.kind = ResultKind.Ok;
     }
 }

--- a/src/test/unit/standalone/string.spec.ts
+++ b/src/test/unit/standalone/string.spec.ts
@@ -20,7 +20,7 @@ import {
     upper,
     whitespace
 } from "../../../lib";
-import { then } from "../../../lib/combinators";
+import { many, then } from "../../../lib/combinators";
 
 const uState = {};
 
@@ -278,6 +278,19 @@ describe("basic string parsers", () => {
         });
         it("fails on long input", () => {
             expect(parser.parse(longInput)).toBeFailure();
+        });
+
+        it("succeeds when used repeatedly", () => {
+            const repeatedParser = stringLen(1).pipe(many());
+            expect(repeatedParser.parse("abcdefg")).toBeSuccessful([
+                "a",
+                "b",
+                "c",
+                "d",
+                "e",
+                "f",
+                "g"
+            ]);
         });
     });
 


### PR DESCRIPTION
With my understanding, the old and deprecated `"".substr` method takes the parameters (`startIndex` and `length`), returning that many characters. But the new `"".substring`, while otherwise appearing similar, takes (`startIndex`, `endIndex`) which provides very different results.

The difference can not be seen unless specific numbers are given - this was not caught in the tests :)

Fixes #107