### PR TITLE
Make "engines" less restrictive in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,6 @@
   },
   "packageManager": "yarn@4.1.1",
   "engines": {
-    "node": "^18.13.0 || ^20.9.0"
+    "node": ">=16.0.0"
   }
 }


### PR DESCRIPTION
The current engines field seems pretty arbitrary. ES2020 (specified in `tsconfig`) fully landed in Node14 but setting it to Node16 to be conservative. 