### PR TITLE
chore: codecov: checking PR workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,6 +44,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
+          plugin: noop
           directory: packages/char-info/coverage
           flags: char-info
 
@@ -54,3 +55,4 @@ jobs:
         with:
           directory: packages/parjs/coverage
           flags: parjs
+          plugin: noop

--- a/packages/parjs/src/internal/combinators/recover.ts
+++ b/packages/parjs/src/internal/combinators/recover.ts
@@ -36,7 +36,6 @@ class Soft<T> extends Combinated<T, T> {
     }
 
     _apply(ps: ParsingState): void {
-        ps.atLeast("Hard");
         this.source.apply(ps);
         if (ps.isOk || ps.isFatal) return;
         const result = this.recoverFunction({


### PR DESCRIPTION
So some notes. I moved the repository from coveralls to codecov because I ran into trouble trying to set coveralls up for a monorepo structure.

Codecov seems more configurable. It has this `codecov.yml` file that you put the configuration in. It wasn't working though. I think the github action was making its own config file or something because the flags, which are needed to differentiate between different packages, weren't being sent.

I spent an embarassing amount of time on this issue and couldn't get it to work. in the end just made it send the flags via github action parameters. That's not as configurable as I'd like but more isn't necessary right now.

This PR is mainly to check to PR workflow